### PR TITLE
Options for skipping steps every save/uniform C++ formatting template

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+IncludeCategories:
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 0 # Note: this will otherwise lead to compilation errors
+    SortPriority: 0 # gtest should always be included first
+  - Regex: ".*"
+    Priority: 1
+    SortPriority: 1

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ htmlcov
 **/charmap.json.gz
 
 /.cache/
-/.clang-format
 /.clangd/
 /.cmake/
 /.dir-locals.el

--- a/cpp_tests/source/benchmarks/bench_cell_lists.cpp
+++ b/cpp_tests/source/benchmarks/bench_cell_lists.cpp
@@ -3,12 +3,11 @@
 #include <random>
 #include <string>
 
+#include "bench_utils.hpp"
 #include "pele/cell_lists.hpp"
 #include "pele/lbfgs.hpp"
 #include "pele/lj_cut.hpp"
 #include "pele/matrix.hpp"
-
-#include "bench_utils.hpp"
 
 using namespace pele;
 using std::string;

--- a/cpp_tests/source/benchmarks/bench_cell_lists_alt.cpp
+++ b/cpp_tests/source/benchmarks/bench_cell_lists_alt.cpp
@@ -3,11 +3,10 @@
 #include <iostream>
 #include <string>
 
+#include "bench_utils.hpp"
 #include "pele/cell_lists.hpp"
 #include "pele/lj_cut.hpp"
 #include "pele/matrix.hpp"
-
-#include "bench_utils.hpp"
 
 using namespace pele;
 using std::string;
@@ -35,7 +34,7 @@ struct LJCellListMaker {
     std::cout << rcut << " " << boxvec << " " << ncellx_scale << "\n";
     auto lj = std::make_shared<LJCutPeriodicCellLists<3>>(4., 4., rcut, boxvec,
                                                           ncellx_scale);
-    double energy = lj->get_energy(x); // this does the initialization
+    double energy = lj->get_energy(x);  // this does the initialization
     std::cout << "initial energy " << energy << "\n";
     return lj;
   }
@@ -51,7 +50,7 @@ int main(int argc, char **argv) {
 
   double neval = 10000;
   size_t natoms = 10;
-  double const target_time_per_run = 5.; // in seconds
+  double const target_time_per_run = 5.;  // in seconds
 
   LJCellListMaker pot_maker(r, rcut, ncellx_scale);
 

--- a/cpp_tests/source/benchmarks/bench_lj.cpp
+++ b/cpp_tests/source/benchmarks/bench_lj.cpp
@@ -3,11 +3,10 @@
 #include <iostream>
 #include <string>
 
+#include "bench_utils.hpp"
 #include "pele/cell_lists.hpp"
 #include "pele/lj_cut.hpp"
 #include "pele/matrix.hpp"
-
-#include "bench_utils.hpp"
 
 using namespace pele;
 using std::string;
@@ -32,7 +31,7 @@ struct LJMaker {
 
     std::cout << rcut << " " << boxvec << "\n";
     auto lj = std::make_shared<LJCutPeriodic>(4., 4., rcut, boxvec);
-    double energy = lj->get_energy(x); // this does the initialization
+    double energy = lj->get_energy(x);  // this does the initialization
     std::cout << "initial energy " << energy << "\n";
     return lj;
   }
@@ -46,7 +45,7 @@ int main(int argc, char **argv) {
 
   double neval = 10000;
   size_t natoms = 10;
-  double const target_time_per_run = 5.; // in seconds
+  double const target_time_per_run = 5.;  // in seconds
 
   LJMaker pot_maker(r, rcut);
 

--- a/cpp_tests/source/benchmarks/bench_minimization.cpp
+++ b/cpp_tests/source/benchmarks/bench_minimization.cpp
@@ -3,12 +3,11 @@
 #include <random>
 #include <string>
 
+#include "bench_utils.hpp"
 #include "pele/array.hpp"
 #include "pele/lbfgs.hpp"
 #include "pele/lj.hpp"
 #include "pele/matrix.hpp"
-
-#include "bench_utils.hpp"
 
 using namespace pele;
 using std::string;

--- a/cpp_tests/source/benchmarks/bench_utils.hpp
+++ b/cpp_tests/source/benchmarks/bench_utils.hpp
@@ -12,7 +12,7 @@
 #include "pele/matrix.hpp"
 
 class Timer {
-public:
+ public:
   double tstart, tstop;
 
   void start() { tstart = clock(); }
@@ -56,8 +56,7 @@ double bench_potential(std::shared_ptr<pele::BasePotential> pot,
   for (size_t i = 0; i < neval; ++i) {
     // change x by some amount and recompute the energy
     double dx = .1;
-    if (i % 5 == 0)
-      dx *= -1;
+    if (i % 5 == 0) dx *= -1;
     x[i % x.size()] += dx;
     pot->get_energy_gradient(x, grad);
     //        if (i % 500 == 0) {
@@ -72,7 +71,7 @@ double bench_potential(std::shared_ptr<pele::BasePotential> pot,
 template <class PotentialMaker>
 double bench_potential_natoms(PotentialMaker &pot_maker, size_t natoms,
                               size_t neval) {
-  std::cout << std::endl; // flush the output
+  std::cout << std::endl;  // flush the output
   std::cout << "======================================================\n";
   std::cout << "benchmarking " << neval << " energy evaluations for " << natoms
             << " atoms\n";

--- a/cpp_tests/source/test_aatopology.cpp
+++ b/cpp_tests/source/test_aatopology.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 #include <limits>
+#include <memory>
 
 #include "pele/aatopology.hpp"
 #include "pele/distance.hpp"
 #include "pele/lj.hpp"
 #include "pele/matrix.hpp"
 #include "pele/vecn.hpp"
-#include <memory>
 using pele::Array;
 using pele::CoordsAdaptor;
 using pele::MatrixNM;
@@ -14,11 +14,11 @@ using pele::norm;
 using pele::VecN;
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   ASSERT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 class AATopologyTest : public ::testing::Test {
-public:
+ public:
   Array<double> x0;
   size_t nrigid;
   std::shared_ptr<pele::RBTopology> rbtopology;
@@ -81,8 +81,7 @@ public:
       auto p = x0.view(3 * nrigid + 3 * i, 3 * nrigid + 3 * i + 3);
       p /= norm(p);
     }
-    for (size_t i = 0; i < 3; ++i)
-      p0[i] = i + 1;
+    for (size_t i = 0; i < 3; ++i) p0[i] = i + 1;
     p0 /= norm(p0);
     rbtopology = std::make_shared<pele::RBTopology>();
     for (size_t i = 0; i < nrigid; ++i) {
@@ -243,8 +242,7 @@ TEST_F(AATopologyTest, TransformRotate_Works) {
   pele::TransformAACluster transform(rbtopology.get());
 
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p);
 
   transform.rotate(x, pele::aa_to_rot_mat(p));

--- a/cpp_tests/source/test_array.cpp
+++ b/cpp_tests/source/test_array.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
-#include "pele/array.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/array.hpp"
 
 using pele::Array;
 
@@ -140,8 +141,7 @@ TEST(ArrayTest, Free_Unwraps) {
 
 TEST(ArrayTest, Copy_WorksNotWrap) {
   pele::Array<double> v(6);
-  for (size_t i = 0; i < v.size(); ++i)
-    v[i] = i;
+  for (size_t i = 0; i < v.size(); ++i) v[i] = i;
   pele::Array<double> v2(6);
   v2 = v.copy();
   EXPECT_NE(v.data(), v2.data());
@@ -152,8 +152,7 @@ TEST(ArrayTest, Copy_WorksNotWrap) {
 
 TEST(ArrayTest, Assign_CopiesNoWrap) {
   pele::Array<double> v(6);
-  for (size_t i = 0; i < v.size(); ++i)
-    v[i] = i;
+  for (size_t i = 0; i < v.size(); ++i) v[i] = i;
   pele::Array<double> v2(6);
   v2.assign(v);
   EXPECT_NE(v.data(), v2.data());
@@ -172,7 +171,7 @@ TEST(ArrayTest, AssignWrongSize_Fails) {
   EXPECT_THROW(v2.assign(v), std::runtime_error);
   v2.free();
   v.free();
-  v2.assign(v); // this is pointless, but it shouldn't fail
+  v2.assign(v);  // this is pointless, but it shouldn't fail
 }
 
 TEST(ArrayTest, ConstructFromVector_Wraps) {
@@ -193,7 +192,7 @@ TEST(ArrayTest, ConstructFromVector_Wraps) {
 
   v.free();
   v2.free();
-  vec[0] = 0; // the data in vec should not have been deallocated
+  vec[0] = 0;  // the data in vec should not have been deallocated
 }
 
 TEST(ArrayTest, RangeBasedFor_Works) {
@@ -225,8 +224,7 @@ TEST(ArrayTest, InEqualityOperator_Works) {
 TEST(ArrayTest, SumOperator_Array) {
   pele::Array<double> v(6, -1);
   pele::Array<double> v2(6, 1);
-  for (size_t i = 0; i < v2.size(); ++i)
-    v2[i] = 1;
+  for (size_t i = 0; i < v2.size(); ++i) v2[i] = 1;
   v += v2;
   EXPECT_NE(v.data(), v2.data());
   for (int i = 0; i < 6; ++i) {
@@ -241,7 +239,7 @@ TEST(ArrayTest, SumOperator_ArraySelf) {
 
   v += v;
 
-  EXPECT_EQ(v.data(), old_v_data); // check that memory has not moved
+  EXPECT_EQ(v.data(), old_v_data);  // check that memory has not moved
 
   for (int i = 0; i < 6; ++i) {
     EXPECT_EQ(v[i], 2);
@@ -309,7 +307,7 @@ TEST(ArrayTest, DifOperator_ArraySelf) {
 
   v -= v;
 
-  EXPECT_EQ(v.data(), old_v_data); // check that memory has not moved
+  EXPECT_EQ(v.data(), old_v_data);  // check that memory has not moved
 
   for (int i = 0; i < 6; ++i) {
     EXPECT_EQ(v[i], 0);
@@ -346,7 +344,7 @@ TEST(ArrayTest, ProdOperator_ArraySelf) {
 
   v *= v;
 
-  EXPECT_EQ(v.data(), old_v_data); // check that memory has not moved
+  EXPECT_EQ(v.data(), old_v_data);  // check that memory has not moved
 
   for (int i = 0; i < 6; ++i) {
     EXPECT_EQ(v[i], 4);
@@ -366,7 +364,6 @@ TEST(ArrayTest, ProdOperator_Const) {
 ///////////
 
 TEST(ArrayTest, AddOperator) {
-
   pele::Array<double> v(6, 2);
   pele::Array<double> vr(6, 10);
   pele::Array<double> vl;
@@ -379,7 +376,6 @@ TEST(ArrayTest, AddOperator) {
 }
 
 TEST(ArrayTest, SubtractOperator) {
-
   pele::Array<double> vr(6, 2);
   pele::Array<double> v(6, 10);
   pele::Array<double> vl;
@@ -423,7 +419,7 @@ TEST(ArrayTest, DivOperator_ArraySelf) {
 
   v /= v;
 
-  EXPECT_EQ(v.data(), old_v_data); // check that memory has not moved
+  EXPECT_EQ(v.data(), old_v_data);  // check that memory has not moved
 
   for (int i = 0; i < 6; ++i) {
     EXPECT_EQ(v[i], 1);

--- a/cpp_tests/source/test_base_potential.cpp
+++ b/cpp_tests/source/test_base_potential.cpp
@@ -1,17 +1,17 @@
-#include "pele/array.hpp"
-#include "pele/base_potential.hpp"
-
 #include <cmath>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
 
+#include "pele/array.hpp"
+#include "pele/base_potential.hpp"
+
 using pele::Array;
 using pele::BasePotential;
 
 class HarmonicE : public pele::BasePotential {
-public:
+ public:
   size_t call_count;
   HarmonicE() : call_count(0) {}
 
@@ -26,7 +26,7 @@ public:
 };
 
 class BasePotentialTest : public ::testing::Test {
-public:
+ public:
   double etrue;
   Array<double> x, g, gtrue, hess, htrue;
   virtual void SetUp() {

--- a/cpp_tests/source/test_blj.cpp
+++ b/cpp_tests/source/test_blj.cpp
@@ -1,13 +1,14 @@
+#include <memory>
+
 #include "pele/atomlist_potential.hpp"
 #include "pele/combine_potentials.hpp"
 #include "pele/distance.hpp"
 #include "pele/lj.hpp"
 #include "pele/lj_cut.hpp"
 #include "test_utils.hpp"
-#include <memory>
 
 class BLJCutTest : public PotentialTest {
-public:
+ public:
   double c6, c12, rcut;
   size_t natoms;
   size_t ntypeA;

--- a/cpp_tests/source/test_cell_list_minimize.cpp
+++ b/cpp_tests/source/test_cell_list_minimize.cpp
@@ -7,16 +7,17 @@
  */
 #include <gtest/gtest.h>
 #include <random>
+#include <vector>
+
 #include "pele/hs_wca.hpp"
 #include "pele/lbfgs.hpp"
 #include "pele/modified_fire.hpp"
-#include <vector>
 
 // Class for making sure the minimizer gives the same answer with and without
 // cell lists
 //
 class CheckInitializerTest : public ::testing::Test {
-public:
+ public:
   static const size_t _ndim = 3;
   size_t nr_particles;
   size_t nr_dof;
@@ -84,7 +85,7 @@ public:
 
 TEST_F(CheckInitializerTest, FullRunFire) {
   double dtstart =
-      0.1; // Parameters match the defaults for the python interface for fire
+      0.1;  // Parameters match the defaults for the python interface for fire
   double dtmax = 1;
   double maxstep = 0.5;
   size_t Nmin = 5;

--- a/cpp_tests/source/test_cell_lists_hs_wca.cpp
+++ b/cpp_tests/source/test_cell_lists_hs_wca.cpp
@@ -1,3 +1,9 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <omp.h>
+#include <ostream>
+#include <random>
+
 #include "pele/array.hpp"
 #include "pele/cell_lists.hpp"
 #include "pele/distance.hpp"
@@ -5,19 +11,15 @@
 #include "pele/inversepower.hpp"
 #include "pele/modified_fire.hpp"
 #include "test_utils.hpp"
-#include <gtest/gtest.h>
-#include <iostream>
-#include <omp.h>
-#include <ostream>
-#include <random>
 
 using pele::Array;
 
-template <size_t ndim> class stupid_counter {
-private:
+template <size_t ndim>
+class stupid_counter {
+ private:
   std::vector<size_t> m_count;
 
-public:
+ public:
   stupid_counter() {
 #ifdef _OPENMP
     m_count = std::vector<size_t>(omp_get_max_threads(), 0);
@@ -51,7 +53,7 @@ size_t get_nr_unique_pairs(Array<double> coords,
 }
 
 class CellListsTestMoreHS_WCA : public ::testing::Test {
-public:
+ public:
   double pow;
   size_t seed;
   std::mt19937_64 generator;
@@ -284,7 +286,7 @@ TEST_F(CellListsTestMoreHS_WCA, HSWCAEnergyCartesian_Works) {
     std::cout << "radii: " << radii << std::endl;
     std::cout << "boxvec: " << boxvec << std::endl;
     pele::HS_WCACellLists<3> pot_cell1(eps, sca, radii, boxvec);
-    
+
     const double e_cell1 = pot_cell1.get_energy(x);
     std::cout << "e_cell1: " << e_cell1 << std::endl;
     pele::HS_WCACellLists<3> pot_cellA(eps, sca, radii, boxvec, factor);
@@ -575,7 +577,7 @@ TEST_F(CellListsTestMoreHS_WCA, HSWCAMinimizationCartesian_Works) {
 }
 
 class CellListsTestMoreHS_WCA2D : public ::testing::Test {
-public:
+ public:
   size_t seed;
   std::mt19937_64 generator;
   std::uniform_real_distribution<double> distribution;

--- a/cpp_tests/source/test_check_copy_assignment_cvode.cpp
+++ b/cpp_tests/source/test_check_copy_assignment_cvode.cpp
@@ -5,17 +5,12 @@
 #include "pele/utils.hpp"
 // optimizer imports
 // #include "pele/extended_mixed_descent.hpp"
-#include "pele/generic_mixed_descent.hpp"
-
 #include "pele/cvode.hpp"
+#include "pele/generic_mixed_descent.hpp"
 #include "pele/lbfgs.hpp"
 #include "pele/modified_fire.hpp"
 
 // potential imports
-#include "pele/inversepower.hpp"
-#include "pele/rosenbrock.hpp"
-
-#include "pele/gradient_descent.hpp"
 #include <cmath>
 #include <cstddef>
 #include <fstream>
@@ -28,6 +23,10 @@
 #include <pele/mxopt.hpp>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/gradient_descent.hpp"
+#include "pele/inversepower.hpp"
+#include "pele/rosenbrock.hpp"
 
 using pele::Array;
 using std::cout;

--- a/cpp_tests/source/test_combinations.cpp
+++ b/cpp_tests/source/test_combinations.cpp
@@ -1,7 +1,6 @@
+#include <gtest/gtest.h>
 #include <numeric>
 #include <random>
-
-#include <gtest/gtest.h>
 
 #include "pele/array.hpp"
 #include "pele/combination.hpp"
@@ -9,11 +8,11 @@
 using pele::make_combination_generator;
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   ASSERT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 class CombinationTest : public ::testing::Test {
-public:
+ public:
   pele::Array<size_t> data;
 
   virtual void SetUp() {

--- a/cpp_tests/source/test_combined_potential.cpp
+++ b/cpp_tests/source/test_combined_potential.cpp
@@ -4,9 +4,8 @@
 #include <stdexcept>
 
 #include "pele/array.hpp"
-#include "pele/inversepower.hpp"
-
 #include "pele/combine_potentials.hpp"
+#include "pele/inversepower.hpp"
 #include "pele/utils.hpp"
 
 using pele::Array;

--- a/cpp_tests/source/test_cvode.cpp
+++ b/cpp_tests/source/test_cvode.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include "pele/cell_lists.hpp"
 #include "pele/cvode.hpp"
 #include "pele/gradient_descent.hpp"
@@ -12,7 +13,6 @@
 
 //#include "pele/mxd_end_only.hpp"
 
-#include "pele/array.hpp"
 #include <cmath>
 #include <iostream>
 #include <memory>
@@ -20,10 +20,10 @@
 #include <stdexcept>
 #include <vector>
 
+#include "pele/array.hpp"
+
 using pele::Array;
 using std::cout;
-
-
 
 TEST(CVODE, IterativeDenseCheck) {
   static const size_t _ndim = 2;

--- a/cpp_tests/source/test_distance.cpp
+++ b/cpp_tests/source/test_distance.cpp
@@ -1,8 +1,7 @@
+#include <gtest/gtest.h>
 #include <iterator>
 #include <numeric>
 #include <random>
-
-#include <gtest/gtest.h>
 
 #include "pele/distance.hpp"
 #include "test_utils.hpp"
@@ -13,14 +12,14 @@ using pele::leesedwards_distance;
 using pele::periodic_distance;
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   ASSERT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 #define TEST_REPEAT 100
 #define BOX_LENGTH 10.0
 
 class DistanceTest : public ::testing::Test {
-public:
+ public:
   pele::Array<double> x2[TEST_REPEAT];
   pele::Array<double> y2[TEST_REPEAT];
   pele::Array<double> x3[TEST_REPEAT];
@@ -232,7 +231,6 @@ TEST_F(DistanceTest, SimplePeriodicNorm_Works) {
   pele::Array<double> bv42(42, BOX_LENGTH);
 
   for (size_t i_repeat = 0; i_repeat < TEST_REPEAT; i_repeat++) {
-
     // compute with periodic_distance
     double dx_periodic_2d[2];
     double dx_periodic_3d[3];
@@ -282,7 +280,6 @@ TEST_F(DistanceTest, LeesEdwards_Image_Y) {
 
   // Compute images using Lees-Edwards
   for (int i = 0; i < 4; i++) {
-
     leesedwards_distance<2>(bv2, shear).put_atom_in_box(r_new[i], r_test[i]);
     leesedwards_distance<2>(bv2, shear).put_atom_in_box(r_test[i]);
     for (int j = 0; j < 2; j++) {
@@ -306,7 +303,6 @@ TEST_F(DistanceTest, LeesEdwards_Image_NotY) {
   pele::Array<double> x42_new = pele::Array<double>(42);
 
   for (size_t i_repeat = 0; i_repeat < TEST_REPEAT; i_repeat++) {
-
     if (i_repeat > 20) {
       x2[0] *= 10;
       x3[0] *= 10;
@@ -380,7 +376,6 @@ TEST_F(DistanceTest, LeesEdwards_NoShear) {
   pele::Array<double> bv42(42, BOX_LENGTH);
 
   for (size_t i_repeat = 0; i_repeat < TEST_REPEAT; i_repeat++) {
-
     // Compute distance with leesedwards_distance
     double dx_leesedwards_2d[2];
     double dx_leesedwards_3d[3];
@@ -427,7 +422,6 @@ TEST_F(DistanceTest, LeesEdwards_ShearPeriodic) {
 
   for (int shear = 0; shear < 10; shear++) {
     for (size_t i_repeat = 0; i_repeat < TEST_REPEAT; i_repeat++) {
-
       // Compute distance with leesedwards_distance
       double dx_leesedwards_2d[2];
       double dx_leesedwards_3d[3];
@@ -491,7 +485,6 @@ TEST_F(DistanceTest, LeesEdwards_Shear) {
 
   for (double shear = 0.1; shear <= 1.0; shear += 0.1) {
     for (size_t i_repeat = 0; i_repeat < TEST_REPEAT; i_repeat++) {
-
       // Compute distance with leesedwards_distance
       double dx_leesedwards_2d[2];
       double dx_leesedwards_3d[3];

--- a/cpp_tests/source/test_eigenvalues.cpp
+++ b/cpp_tests/source/test_eigenvalues.cpp
@@ -1,8 +1,3 @@
-#include "pele/array.hpp"
-#include "pele/eigen_interface.hpp"
-#include "pele/inversepower.hpp"
-#include "pele/lbfgs.hpp"
-#include "pele/lowest_eig_potential.hpp"
 #include <Eigen/Dense>
 #include <cmath>
 #include <gtest/gtest.h>
@@ -11,9 +6,14 @@
 #include <stdexcept>
 #include <vector>
 
+#include "pele/array.hpp"
+#include "pele/eigen_interface.hpp"
+#include "pele/inversepower.hpp"
+#include "pele/lbfgs.hpp"
+#include "pele/lowest_eig_potential.hpp"
+
 using namespace Eigen;
 using namespace pele;
-
 
 void compute_lowest_eigenvalue(MatrixXd m) {
   // check whether the lowest eigenvalue is negative
@@ -28,7 +28,7 @@ void setup() {
   double rsca;
   double energy;
   //////////// parameters for inverse power potential at packing fraction 0.7 in
-  ///3d
+  /// 3d
   //////////// as generated from code params.py in basinerror library
 
   pele::Array<double> x;
@@ -106,6 +106,5 @@ void setup() {
 
   std::cout << lowesteigenvalue << "lowest eigenvalue from pele \n";
 }
-
 
 TEST(EIG, sym) { setup(); }

--- a/cpp_tests/source/test_fire.cpp
+++ b/cpp_tests/source/test_fire.cpp
@@ -1,9 +1,8 @@
 #include <cmath>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include "pele/lj.hpp"
 #include "pele/modified_fire.hpp"

--- a/cpp_tests/source/test_frozen.cpp
+++ b/cpp_tests/source/test_frozen.cpp
@@ -1,10 +1,10 @@
-#include "pele/array.hpp"
-#include "pele/frozen_atoms.hpp"
-#include "pele/lj.hpp"
-
 #include <gtest/gtest.h>
 #include <iostream>
 #include <stdexcept>
+
+#include "pele/array.hpp"
+#include "pele/frozen_atoms.hpp"
+#include "pele/lj.hpp"
 
 using pele::Array;
 using pele::LJ;
@@ -13,7 +13,7 @@ using pele::LJ;
  * Pairwise Lennard-Jones potential with frozen atoms
  */
 class LJFrozen : public pele::FrozenPotentialWrapper {
-public:
+ public:
   LJFrozen(double C6, double C12, Array<double> const &reference_coords,
            Array<size_t> const &frozen_dof)
       : pele::FrozenPotentialWrapper(std::make_shared<LJ>(C6, C12),
@@ -21,7 +21,7 @@ public:
 };
 
 class FrozenLJTest : public ::testing::Test {
-public:
+ public:
   double c6, c12, etrue;
   Array<double> x, y;
   Array<size_t> frozen_dof;

--- a/cpp_tests/source/test_gaussianpot.cpp
+++ b/cpp_tests/source/test_gaussianpot.cpp
@@ -1,15 +1,13 @@
-#include <memory>
-
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "pele/array.hpp"
 #include "pele/gaussianpot.hpp"
 #include "pele/modified_fire.hpp"
-
 #include "test_utils.hpp"
 
 class TestGaussianPot : public ::testing::Test {
-public:
+ public:
   size_t ndim, npot, ndof;
   virtual void SetUp() {
     ndim = 2;
@@ -86,7 +84,7 @@ TEST_F(TestGaussianPot, OneGaussWorksNonZero) {
 }
 
 class TestGaussianPotAuto : public PotentialTest {
-public:
+ public:
   size_t ndim, npot, ndof;
   pele::Array<double> mean, cov;
   virtual void SetUp() {

--- a/cpp_tests/source/test_generic_mixed_descent.cpp
+++ b/cpp_tests/source/test_generic_mixed_descent.cpp
@@ -5,17 +5,12 @@
 #include "pele/utils.hpp"
 // optimizer imports
 // #include "pele/extended_mixed_descent.hpp"
-#include "pele/generic_mixed_descent.hpp"
-
 #include "pele/cvode.hpp"
+#include "pele/generic_mixed_descent.hpp"
 #include "pele/lbfgs.hpp"
 #include "pele/modified_fire.hpp"
 
 // potential imports
-#include "pele/inversepower.hpp"
-#include "pele/rosenbrock.hpp"
-
-#include "pele/gradient_descent.hpp"
 #include <cmath>
 #include <complex>
 #include <cstddef>
@@ -29,6 +24,10 @@
 #include <pele/mxopt.hpp>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/gradient_descent.hpp"
+#include "pele/inversepower.hpp"
+#include "pele/rosenbrock.hpp"
 
 using pele::Array;
 using std::cout;

--- a/cpp_tests/source/test_harmonic.cpp
+++ b/cpp_tests/source/test_harmonic.cpp
@@ -1,26 +1,24 @@
 #include <cassert>
 #include <cmath>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <vector>
 
-#include <gtest/gtest.h>
-
 #include "pele/harmonic.hpp"
 #include "pele/meta_pow.hpp"
-
 #include "test_utils.hpp"
 
 using pele::Array;
 using pele::pos_int_pow;
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 class HarmonicTest : public ::testing::Test {
-public:
+ public:
   size_t nr_particles;
   size_t box_dimension;
   size_t nr_dof;
@@ -85,7 +83,7 @@ TEST_F(HarmonicTest, COM_Works) {
 }
 
 class HarmonicAtomListTest : public PotentialTest {
-public:
+ public:
   double natoms;
   double k;
 
@@ -130,7 +128,7 @@ TEST_F(HarmonicAtomListTest, EnergyGradientHessian_AgreesWithNumerical) {
 }
 
 class HarmonicNeighborListTest : public HarmonicAtomListTest {
-public:
+ public:
   virtual void setup_potential() {
     pele::Array<size_t> nlist(natoms * (natoms - 1));
     size_t count = 0;

--- a/cpp_tests/source/test_hoomd.cpp
+++ b/cpp_tests/source/test_hoomd.cpp
@@ -27,8 +27,9 @@
 // typedef PotentialPair<EvaluatorPairLJ> PotentialPairLJ;
 
 // static double const EPS = std::numeric_limits<double>::min();
-// #define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
-//   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
+// #define EXPECT_NEAR_RELATIVE(A, B, T) \
+//   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS),
+//   T)
 
 // typedef std::function<std::shared_ptr<PotentialPairLJ>(
 //     std::shared_ptr<SystemDefinition> sysdef,
@@ -38,31 +39,41 @@
 // TEST(HOOMD, GET_FORCE_AND_ENERGY) {
 //     // this 3-particle test subtly checks several conditions
 //     // the particles are arranged on the x axis,  1   2   3
-//     // such that 2 is inside the cutoff radius of 1 and 3, but 1 and 3 are outside the cutoff
-//     // of course, the buffer will be set on the neighborlist so that 3 is included in it
-//     // thus, this case tests the ability of the force summer to sum more than one force on
+//     // such that 2 is inside the cutoff radius of 1 and 3, but 1 and 3 are
+//     outside the cutoff
+//     // of course, the buffer will be set on the neighborlist so that 3 is
+//     included in it
+//     // thus, this case tests the ability of the force summer to sum more than
+//     one force on
 //     // a particle and ignore a particle outside the radius
 
 //     // periodic boundary conditions will be handled in another test
 
-//     ljforce_creator lj_creator = [] (std::shared_ptr<SystemDefinition> sys_def, std::shared_ptr<NeighborList> nlist) {
-//       return std::shared_ptr<PotentialPairLJ>(new PotentialPairLJ(sys_def, nlist));
+//     ljforce_creator lj_creator = [] (std::shared_ptr<SystemDefinition>
+//     sys_def, std::shared_ptr<NeighborList> nlist) {
+//       return std::shared_ptr<PotentialPairLJ>(new PotentialPairLJ(sys_def,
+//       nlist));
 //     };
 
-
-    
-//     // std::shared_ptr<ExecutionConfiguration> exec_conf = std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU));
-//     // std::shared_ptr<SystemDefinition> sysdef_3(new SystemDefinition(3, BoxDim(1000.0), 1, 0, 0, 0, 0, exec_conf));
+//     // std::shared_ptr<ExecutionConfiguration> exec_conf =
+//     std::shared_ptr<ExecutionConfiguration>(new
+//     ExecutionConfiguration(ExecutionConfiguration::CPU));
+//     // std::shared_ptr<SystemDefinition> sysdef_3(new SystemDefinition(3,
+//     BoxDim(1000.0), 1, 0, 0, 0, 0, exec_conf));
 //     // std::shared_ptr<ParticleData> pdata_3 = sysdef_3->getParticleData();
 //     // pdata_3->setFlags(~PDataFlags(0));
 
 //     // {
-//     // ArrayHandle<Scalar4> h_pos(pdata_3->getPositions(), access_location::host, access_mode::readwrite);
+//     // ArrayHandle<Scalar4> h_pos(pdata_3->getPositions(),
+//     access_location::host, access_mode::readwrite);
 //     // h_pos.data[0].x = h_pos.data[0].y = h_pos.data[0].z = 0.0;
-//     // h_pos.data[1].x = Scalar(pow(2.0,1.0/6.0)); h_pos.data[1].y = h_pos.data[1].z = 0.0;
-//     // h_pos.data[2].x = Scalar(2.0*pow(2.0,1.0/6.0)); h_pos.data[2].y = h_pos.data[2].z = 0.0;
+//     // h_pos.data[1].x = Scalar(pow(2.0,1.0/6.0)); h_pos.data[1].y =
+//     h_pos.data[1].z = 0.0;
+//     // h_pos.data[2].x = Scalar(2.0*pow(2.0,1.0/6.0)); h_pos.data[2].y =
+//     h_pos.data[2].z = 0.0;
 //     // }
-//     // std::shared_ptr<NeighborListTree> nlist_3(new NeighborListTree(sysdef_3, Scalar(1.3), Scalar(3.0)));
+//     // std::shared_ptr<NeighborListTree> nlist_3(new
+//     NeighborListTree(sysdef_3, Scalar(1.3), Scalar(3.0)));
 //     // std::shared_ptr<PotentialPairLJ> fc_3 = lj_creator(sysdef_3, nlist_3);
 //     // fc_3->setRcut(0, 0, Scalar(1.3));
 

--- a/cpp_tests/source/test_inversepower.cpp
+++ b/cpp_tests/source/test_inversepower.cpp
@@ -9,7 +9,7 @@ using pele::Array;
 using pele::InversePower;
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 /*
@@ -17,7 +17,7 @@ static double const EPS = std::numeric_limits<double>::min();
  */
 
 class InversePowerTest : public ::testing::Test {
-public:
+ public:
   double pow, eps, etrue;
   Array<double> x, g, gnum, radii;
   virtual void SetUp() {
@@ -166,7 +166,8 @@ TEST_F(InversePowerTest, InverseHalfIntPower_AgreesWithInversePower) {
 
 // BEGIN: TEST_F(InversePowerTest, MetaPowFunctionsLoop_Work)
 
-template <int N> struct perform_tests {
+template <int N>
+struct perform_tests {
   /**
    *This test should work fine.
    *The comparison is to Mathematica.
@@ -388,7 +389,8 @@ template <int N> struct perform_tests {
   }
 };
 
-template <> struct perform_tests<0> {
+template <>
+struct perform_tests<0> {
   static void f(const double op) {
     const double true_result_direct = 1;
     const double true_result_std = std::pow(op, 0);
@@ -397,7 +399,8 @@ template <> struct perform_tests<0> {
   }
 };
 
-template <int N> inline void perform_tests_zero_to(const double op) {
+template <int N>
+inline void perform_tests_zero_to(const double op) {
   return perform_tests<N>::f(op);
 }
 

--- a/cpp_tests/source/test_inversepower_stillinger.cpp
+++ b/cpp_tests/source/test_inversepower_stillinger.cpp
@@ -1,15 +1,14 @@
 #include <gtest/gtest.h>
 
 #include "pele/inversepower_stillinger.hpp"
-
 #include "test_utils.hpp"
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 class BasicIPSTest : public ::testing::Test {
-public:
+ public:
   size_t ndim;
   size_t ndof;
   size_t npart;

--- a/cpp_tests/source/test_inversepower_stillinger_cut.cpp
+++ b/cpp_tests/source/test_inversepower_stillinger_cut.cpp
@@ -1,15 +1,14 @@
 #include <gtest/gtest.h>
 
 #include "pele/inversepower_stillinger_cut.hpp"
-
 #include "test_utils.hpp"
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 class BasicIPSCutTest : public ::testing::Test {
-public:
+ public:
   size_t ndim;
   size_t ndof;
   size_t npart;

--- a/cpp_tests/source/test_inversepower_stillinger_cut_quad.cpp
+++ b/cpp_tests/source/test_inversepower_stillinger_cut_quad.cpp
@@ -7,11 +7,11 @@
 #include "pele/inversepower_stillinger_cut_quad.hpp"
 #include "test_utils.hpp"
 
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 class BasicIPSCutQuadTest : public ::testing::Test {
-public:
+ public:
   size_t ndim;
   size_t ndof;
   size_t npart;
@@ -83,8 +83,6 @@ TEST_F(BasicIPSCutQuadTest, Pow_Works) {
   }
 }
 
-
-
 TEST_F(BasicIPSCutQuadTest, Energy_WorksIntPower12) {
   // TODO: Figure out how to do a constexpr loop
   constexpr size_t power = 12;
@@ -121,14 +119,13 @@ TEST_F(BasicIPSCutQuadTest, zero_at_cutoff) {
   }
 }
 
-
 /*
-* Base class for testing variants of the InversePowerStillingerCutQuad
-* potential. The potential should the same but different optimizations are 
-* made based on information available at compile time
-*/
-class BaseTestInversePowerStillingerCutQuadAuto  : public PotentialTest {
-protected:
+ * Base class for testing variants of the InversePowerStillingerCutQuad
+ * potential. The potential should the same but different optimizations are
+ * made based on information available at compile time
+ */
+class BaseTestInversePowerStillingerCutQuadAuto : public PotentialTest {
+ protected:
   size_t ndim;
   size_t ndof;
   size_t npart;
@@ -140,7 +137,7 @@ protected:
 
   double v0, cutoff_factor, expected_cutoff;
 
-    // Expected energy for a pair of particles with distance dr
+  // Expected energy for a pair of particles with distance dr
   // Expected energy for a pair of particles with distance dr
   double get_test_energy(double dr, double cutoff_factor, double v0, int pow,
                          Array<double> radii) {
@@ -176,11 +173,10 @@ protected:
     double dr = std::sqrt(std::pow(x[0] - x[2], 2) + std::pow(x[1] - x[3], 2));
     etrue = get_test_energy(dr, cutoff_factor, v0, exponent, radii);
   }
-
 };
 
-class TestInversePowerStillingerCutQuadAuto : public BaseTestInversePowerStillingerCutQuadAuto {
-
+class TestInversePowerStillingerCutQuadAuto
+    : public BaseTestInversePowerStillingerCutQuadAuto {
   virtual void SetUp() {
     init_potential_parameters();
     pot = std::make_shared<pele::InversePowerStillingerCutQuad<2>>(
@@ -200,9 +196,8 @@ TEST_F(TestInversePowerStillingerCutQuadAuto,
   test_energy_gradient_hessian();
 }
 
-
-class TestInversePowerStillingerCutQuadAutoInt : public BaseTestInversePowerStillingerCutQuadAuto {
-
+class TestInversePowerStillingerCutQuadAutoInt
+    : public BaseTestInversePowerStillingerCutQuadAuto {
   virtual void SetUp() {
     init_potential_parameters();
     pot = std::make_shared<pele::InversePowerStillingerCutQuadInt<2, exponent>>(
@@ -221,5 +216,3 @@ TEST_F(TestInversePowerStillingerCutQuadAutoInt,
        EnergyGradientHessian_AgreesWithNumerical) {
   test_energy_gradient_hessian();
 }
-
-

--- a/cpp_tests/source/test_lbfgs.cpp
+++ b/cpp_tests/source/test_lbfgs.cpp
@@ -1,4 +1,10 @@
+#include <cmath>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
 #include "pele/cvode.hpp"
 #include "pele/gradient_descent.hpp"
 #include "pele/harmonic.hpp"
@@ -6,11 +12,6 @@
 #include "pele/lj.hpp"
 #include "pele/mxopt.hpp"
 #include "pele/rosenbrock.hpp"
-#include <cmath>
-#include <iostream>
-#include <memory>
-#include <stdexcept>
-#include <vector>
 
 using pele::Array;
 using std::cout;

--- a/cpp_tests/source/test_lj.cpp
+++ b/cpp_tests/source/test_lj.cpp
@@ -1,14 +1,14 @@
-#include "pele/array.hpp"
-#include "pele/lj.hpp"
-#include "pele/lj_cut.hpp"
-#include "test_utils.hpp"
-
 #include <cmath>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/array.hpp"
+#include "pele/lj.hpp"
+#include "pele/lj_cut.hpp"
+#include "test_utils.hpp"
 
 using pele::Array;
 
@@ -44,7 +44,7 @@ TEST(LJInteractionTest, Hessian_Works) {
 }
 
 class LJTest : public PotentialTest {
-public:
+ public:
   double c6, c12;
   size_t natoms;
 
@@ -116,7 +116,7 @@ TEST_F(LJNeighborListTest, EnergyGradientHessian_AgreesWithNumerical) {
 }
 
 class LJCutTest : public PotentialTest {
-public:
+ public:
   double c6, c12, rcut;
   size_t natoms;
 
@@ -162,7 +162,7 @@ TEST_F(LJCutTest, EnergyGradientHessian_AgreesWithNumerical) {
  */
 
 class LJCutAtomListTest : public LJCutTest {
-public:
+ public:
   virtual void setup_potential() {
     pele::Array<size_t> atoms(natoms);
     for (size_t i = 0; i < atoms.size(); ++i) {
@@ -184,7 +184,7 @@ TEST_F(LJCutAtomListTest, EnergyGradientHessian_AgreesWithNumerical) {
 }
 
 class LJCutPeriodicAtomListTest : public LJCutTest {
-public:
+ public:
   virtual void setup_potential() {
     // make the box huge, soe the energy is not affected
     // but displace some of the atoms, to check that the distances are being

--- a/cpp_tests/source/test_lowest_eig_potential.cpp
+++ b/cpp_tests/source/test_lowest_eig_potential.cpp
@@ -1,20 +1,20 @@
-#include <gtest/gtest.h>
-#include "pele/array.hpp"
-#include "pele/lbfgs.hpp"
-#include "pele/lj.hpp"
-#include "pele/lowest_eig_potential.hpp"
-
 #include <cmath>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <vector>
 
+#include "pele/array.hpp"
+#include "pele/lbfgs.hpp"
+#include "pele/lj.hpp"
+#include "pele/lowest_eig_potential.hpp"
+
 using pele::Array;
 using pele::BasePotential;
 
 class LowestEigPotentialTest : public ::testing::Test {
-public:
+ public:
   std::shared_ptr<pele::BasePotential> _potential;
   std::shared_ptr<pele::LowestEigPotential> _lowesteigpot;
   std::shared_ptr<pele::GradientOptimizer> _lbfgs;
@@ -49,12 +49,9 @@ public:
     ev1.assign(0.0);
     ev2.assign(0.0);
     double v = 1 / sqrt(_natoms);
-    for (size_t j = 0; j < _ndim; j += _bdim)
-      ev0[j] = v;
-    for (size_t j = 1; j < _ndim; j += _bdim)
-      ev1[j] = v;
-    for (size_t j = 2; j < _ndim; j += _bdim)
-      ev2[j] = v;
+    for (size_t j = 0; j < _ndim; j += _bdim) ev0[j] = v;
+    for (size_t j = 1; j < _ndim; j += _bdim) ev1[j] = v;
+    for (size_t j = 2; j < _ndim; j += _bdim) ev2[j] = v;
     // setup potential
     _potential = std::shared_ptr<pele::BasePotential>(new pele::LJ(_c6, _c12));
     // setup LBFGS
@@ -64,8 +61,7 @@ public:
     // setup lowesteigtest
     _g = Array<double>(_ndim);
     _ranvec = Array<double>(_ndim);
-    for (size_t j = 0; j < _ndim; ++j)
-      _ranvec[j] = (double)j;
+    for (size_t j = 0; j < _ndim; ++j) _ranvec[j] = (double)j;
     _ranvec /= norm(_ranvec);
   }
 };
@@ -133,7 +129,7 @@ TEST_F(LowestEigPotentialTest, LowestEig_ranvecorth) {
 }
 
 class OrthogonalizeTranslationalTest : public ::testing::Test {
-public:
+ public:
   pele::Array<double> ev0, ev1, ev2, _vector, _coords;
   size_t _natoms, _bdim, _ndim;
   std::shared_ptr<pele::Orthogonalize> _orthog;
@@ -151,16 +147,12 @@ public:
     ev1.assign(0.0);
     ev2.assign(0.0);
     double v = 1 / sqrt(_natoms);
-    for (size_t j = 0; j < _ndim; j += _bdim)
-      ev0[j] = v;
-    for (size_t j = 1; j < _ndim; j += _bdim)
-      ev1[j] = v;
-    for (size_t j = 2; j < _ndim; j += _bdim)
-      ev2[j] = v;
+    for (size_t j = 0; j < _ndim; j += _bdim) ev0[j] = v;
+    for (size_t j = 1; j < _ndim; j += _bdim) ev1[j] = v;
+    for (size_t j = 2; j < _ndim; j += _bdim) ev2[j] = v;
     _vector = Array<double>(_ndim);
     _coords = Array<double>(_ndim);
-    for (size_t j = 0; j < _ndim; ++j)
-      _vector[j] = (double)j;
+    for (size_t j = 0; j < _ndim; ++j) _vector[j] = (double)j;
     _vector /= norm(_vector);
     _coords.assign(10);
   };
@@ -186,6 +178,5 @@ TEST_F(OrthogonalizeTranslationalTest, orthogonalize_works2) {
 
 TEST_F(OrthogonalizeTranslationalTest, orthogonalize_works3) {
   _orthog->orthogonalize(_coords, _vector);
-  for (size_t i = 0; i < _ndim; ++i)
-    ASSERT_EQ(_coords[i], 10);
+  for (size_t i = 0; i < _ndim; ++i) ASSERT_EQ(_coords[i], 10);
 }

--- a/cpp_tests/source/test_matrix.cpp
+++ b/cpp_tests/source/test_matrix.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
-
-#include "pele/matrix.hpp"
-#include "pele/vecn.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/matrix.hpp"
+#include "pele/vecn.hpp"
 
 using pele::Array;
 using pele::MatrixAdapter;

--- a/cpp_tests/source/test_mixed_descent.cpp
+++ b/cpp_tests/source/test_mixed_descent.cpp
@@ -7,15 +7,15 @@
 #include "pele/mxopt.hpp"
 
 // potential imports
-#include "pele/inversepower.hpp"
-#include "pele/rosenbrock.hpp"
-
-#include "pele/gradient_descent.hpp"
 #include <cmath>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/gradient_descent.hpp"
+#include "pele/inversepower.hpp"
+#include "pele/rosenbrock.hpp"
 
 using pele::Array;
 using std::cout;

--- a/cpp_tests/source/test_mixed_descent_extended_potential.cpp
+++ b/cpp_tests/source/test_mixed_descent_extended_potential.cpp
@@ -9,10 +9,6 @@
 #include "pele/modified_fire.hpp"
 
 // potential imports
-#include "pele/inversepower.hpp"
-#include "pele/rosenbrock.hpp"
-
-#include "pele/gradient_descent.hpp"
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -22,6 +18,10 @@
 #include <pele/modified_fire.hpp>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/gradient_descent.hpp"
+#include "pele/inversepower.hpp"
+#include "pele/rosenbrock.hpp"
 
 using pele::Array;
 using std::cout;
@@ -243,5 +243,4 @@ TEST(EXTENDED_MXD, TEST_256_RUN_ITERATIVE) {
             << std::endl;
   std::cout << "n failed phase 2 steps"
             << optimizer_mxopt.get_n_failed_phase_2_steps() << std::endl;
-
 }

--- a/cpp_tests/source/test_morse.cpp
+++ b/cpp_tests/source/test_morse.cpp
@@ -1,16 +1,17 @@
-#include <gtest/gtest.h>
-#include "pele/array.hpp"
-#include "pele/morse.hpp"
-#include "test_utils.hpp"
 #include <cmath>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
 
+#include "pele/array.hpp"
+#include "pele/morse.hpp"
+#include "test_utils.hpp"
+
 using pele::Array;
 
 class MorseTest : public PotentialTest {
-public:
+ public:
   double rho, r0, A;
   void SetUp() {
     rho = 1.2;

--- a/cpp_tests/source/test_newton.cpp
+++ b/cpp_tests/source/test_newton.cpp
@@ -1,12 +1,13 @@
 // Tests for Newton's method with singular values
-#include <gtest/gtest.h>
-#include "pele/array.hpp"
 #include <cstddef>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <pele/harmonic.hpp>
 #include <pele/newton.hpp>
 #include <pele/rosenbrock.hpp>
+
+#include "pele/array.hpp"
 
 using pele::Array;
 using std::cout;

--- a/cpp_tests/source/test_ngt.cpp
+++ b/cpp_tests/source/test_ngt.cpp
@@ -1,6 +1,7 @@
+#include <gtest/gtest.h>
+
 #include "pele/graph.hpp"
 #include "pele/ngt.hpp"
-#include <gtest/gtest.h>
 
 using pele::NGT;
 using pele::node_id;
@@ -17,7 +18,7 @@ TEST(Graph, AddDuplicateEdges_NoEffect) {
 }
 
 class NGT3 : public ::testing::Test {
-public:
+ public:
   NGT::rate_map_t rate_map;
   std::set<node_id> A, B;
   virtual void SetUp() {
@@ -53,15 +54,14 @@ TEST_F(NGT3, RatesCommittors_Correct) {
 }
 
 class NGT10 : public ::testing::Test {
-public:
+ public:
   NGT::rate_map_t rate_map;
   std::set<node_id> A, B;
   double kAB, kBA, kABSS, kBASS;
   virtual void SetUp() {
     for (int i = 0; i < 10; ++i) {
       for (int j = 0; j < 10; ++j) {
-        if (i == j)
-          continue;
+        if (i == j) continue;
         rate_map[std::pair<node_id, node_id>(i, j)] = double(i + j) / (i + 1);
       }
     }

--- a/cpp_tests/source/test_pressure.cpp
+++ b/cpp_tests/source/test_pressure.cpp
@@ -1,5 +1,4 @@
 #include <cmath>
-
 #include <gtest/gtest.h>
 
 #include "pele/inversepower.hpp"

--- a/cpp_tests/source/test_pspin.cpp
+++ b/cpp_tests/source/test_pspin.cpp
@@ -1,16 +1,16 @@
+#include <fstream>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <stdexcept>
+
 #include "pele/array.hpp"
 #include "pele/combination.hpp"
 #include "pele/meta_pow.hpp"
 #include "pele/pspin_spherical.hpp"
 #include "test_utils.hpp"
 
-#include <fstream>
-#include <iostream>
-#include <stdexcept>
-
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 using pele::Array;
@@ -19,7 +19,7 @@ using pele::MeanFieldPSpinSpherical;
 using pele::pos_int_pow;
 
 class MeanFieldPSpinSphericalTestP4 : public PotentialTest {
-public:
+ public:
   size_t n;
   Array<double> interactions;
   double tol;
@@ -39,7 +39,7 @@ public:
 };
 
 class MeanFieldPSpinSphericalTestP4_2 : public PotentialTest {
-public:
+ public:
   size_t n;
   Array<double> interactions;
   double tol;
@@ -65,7 +65,7 @@ public:
 };
 
 class MeanFieldPSpinSphericalTestP2 : public PotentialTest {
-public:
+ public:
   size_t n;
   Array<double> interactions;
   double tol;
@@ -85,7 +85,7 @@ public:
 };
 
 class MeanFieldPSpinSphericalTestP2_2 : public PotentialTest {
-public:
+ public:
   size_t n;
   Array<double> interactions;
   double tol;

--- a/cpp_tests/source/test_rattlers.cpp
+++ b/cpp_tests/source/test_rattlers.cpp
@@ -11,12 +11,13 @@
  * @copyright Copyright (c) 2021
  *
  */
-#include <gtest/gtest.h>
-#include "pele/array.hpp"
-#include "pele/inversepower.hpp"
 #include "gtest/internal/gtest-internal.h"
 #include <cstddef>
+#include <gtest/gtest.h>
 #include <memory>
+
+#include "pele/array.hpp"
+#include "pele/inversepower.hpp"
 
 using pele::Array;
 /*
@@ -26,7 +27,6 @@ using pele::Array;
  *          python code.
  */
 TEST(Rattlers, CompareToJulia) {
-
   // potential parameters
   double eps = 1.0;
   double sigma = 1.0;

--- a/cpp_tests/source/test_rotations.cpp
+++ b/cpp_tests/source/test_rotations.cpp
@@ -12,13 +12,12 @@ using pele::norm;
 using pele::VecN;
 
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   ASSERT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 TEST(Rotations, AA2RotMat_Works) {
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p);
   auto mx = pele::aa_to_rot_mat(p);
   ASSERT_NEAR(mx(0, 0), 0.57313786, 1e-5);
@@ -34,8 +33,7 @@ TEST(Rotations, AA2RotMat_Works) {
 
 TEST(Rotations, RotMat2q_Works) {
   MatrixNM<3, 3> mx;
-  for (size_t i = 0; i < mx.size(); ++i)
-    mx.data()[i] = i;
+  for (size_t i = 0; i < mx.size(); ++i) mx.data()[i] = i;
   VecN<4> q = pele::rot_mat_to_quaternion(mx);
   ASSERT_NEAR(q[0], 1.80277564, 1e-5);
   ASSERT_NEAR(q[1], 0.2773501, 1e-5);
@@ -45,13 +43,11 @@ TEST(Rotations, RotMat2q_Works) {
 
 TEST(Rotations, Quaternion2AA_Works) {
   VecN<3> v;
-  for (size_t i = 0; i < v.size(); ++i)
-    v[i] = i + 1;
+  for (size_t i = 0; i < v.size(); ++i) v[i] = i + 1;
   v /= norm<3>(v);
 
   VecN<4> q(4);
-  for (size_t i = 0; i < 3; ++i)
-    q[i + 1] = v[i];
+  for (size_t i = 0; i < 3; ++i) q[i + 1] = v[i];
   //    std::cout << q << std::endl;
 
   VecN<3> aa = pele::quaternion_to_aa(q);
@@ -62,8 +58,7 @@ TEST(Rotations, Quaternion2AA_Works) {
 
 TEST(Rotations, RotMat2aa_Works) {
   MatrixNM<3, 3> mx;
-  for (size_t i = 0; i < mx.size(); ++i)
-    mx.data()[i] = i;
+  for (size_t i = 0; i < mx.size(); ++i) mx.data()[i] = i;
   VecN<3> p = pele::rot_mat_to_aa(mx);
   ASSERT_NEAR(p[0], 0.29425463, 1e-5);
   ASSERT_NEAR(p[1], -0.58850926, 1e-5);
@@ -72,10 +67,8 @@ TEST(Rotations, RotMat2aa_Works) {
 
 TEST(Rotations, QuaternionMultiply_Works) {
   VecN<4> q1, q2;
-  for (size_t i = 0; i < q1.size(); ++i)
-    q1[i] = i + 1;
-  for (size_t i = 0; i < q2.size(); ++i)
-    q2[i] = i + 2;
+  for (size_t i = 0; i < q1.size(); ++i) q1[i] = i + 1;
+  for (size_t i = 0; i < q2.size(); ++i) q2[i] = i + 2;
 
   VecN<4> q3 = pele::quaternion_multiply(q1, q2);
   ASSERT_NEAR(q3[0], -36., 1e-5);
@@ -86,8 +79,7 @@ TEST(Rotations, QuaternionMultiply_Works) {
 
 TEST(Rotations, AA2Q_Works) {
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p);
   VecN<4> q = pele::aa_to_quaternion(p);
   ASSERT_NEAR(q[0], 0.87758256, 1e-5);
@@ -98,8 +90,7 @@ TEST(Rotations, AA2Q_Works) {
 
 TEST(Rotations, AA2QAndBack_Works) {
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p);
   VecN<3> pnew = pele::quaternion_to_aa(pele::aa_to_quaternion(p));
 
@@ -110,8 +101,7 @@ TEST(Rotations, AA2QAndBack_Works) {
 
 TEST(Rotations, RotateAA_Works) {
   VecN<3> p1, p2;
-  for (size_t i = 0; i < p1.size(); ++i)
-    p1[i] = i + 1;
+  for (size_t i = 0; i < p1.size(); ++i) p1[i] = i + 1;
   p2 = p1;
   p2 += 1;
   VecN<3> p3 = pele::rotate_aa(p1, p2);
@@ -123,8 +113,7 @@ TEST(Rotations, RotateAA_Works) {
 
 TEST(RotMatDerivs, Works) {
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p);
   MatrixNM<3, 3> mx(1.);
   MatrixNM<3, 3> drm1(0.);
@@ -167,8 +156,7 @@ TEST(RotMatDerivs, Works) {
 
 TEST(RotMatDerivs, SmallTheta_Works) {
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p) * 1e7;
   MatrixNM<3, 3> mx(1.);
   MatrixNM<3, 3> drm1(0.);
@@ -211,8 +199,7 @@ TEST(RotMatDerivs, SmallTheta_Works) {
 
 TEST(RotMatDerivs, SmallTheta2_Works) {
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p) * 1e7;
   MatrixNM<3, 3> mx(1.);
   MatrixNM<3, 3> drm1(0.);
@@ -237,8 +224,7 @@ TEST(RotMatDerivs, SmallTheta2_Works) {
 
 TEST(RotMat, SmallTheta_Works) {
   VecN<3> p;
-  for (size_t i = 0; i < p.size(); ++i)
-    p[i] = i + 1;
+  for (size_t i = 0; i < p.size(); ++i) p[i] = i + 1;
   p /= norm<3>(p) * 1e7;
 
   auto mx = pele::aa_to_rot_mat(p);

--- a/cpp_tests/source/test_utils.cpp
+++ b/cpp_tests/source/test_utils.cpp
@@ -1,17 +1,17 @@
-#include <gtest/gtest.h>
-#include "pele/array.hpp"
-#include "pele/utils.hpp"
-
 #include <cmath>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <vector>
 
+#include "pele/array.hpp"
+#include "pele/utils.hpp"
+
 using pele::Array;
 
 TEST(utils, box_length_3d) {
-  Array<double> hs_radii{1.0, 1.0, 1.0, 1.0, 1.0, 1.0}; // radii
+  Array<double> hs_radii{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};  // radii
 
   double dim = 3.0;
 
@@ -23,7 +23,7 @@ TEST(utils, box_length_3d) {
 }
 
 TEST(utils, box_length_2d) {
-  Array<double> hs_radii{1.0, 1.0, 1.0, 1.0, 1.0, 1.0}; // radii
+  Array<double> hs_radii{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};  // radii
 
   double dim = 2.0;
 

--- a/cpp_tests/source/test_utils.hpp
+++ b/cpp_tests/source/test_utils.hpp
@@ -1,21 +1,21 @@
 #ifndef __PELE_TEST_UTILS_HPP__
 #define __PELE_TEST_UTILS_HPP__
-#include <gtest/gtest.h>
-#include "pele/array.hpp"
-#include "pele/base_potential.hpp"
-
 #include <cmath>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 
+#include "pele/array.hpp"
+#include "pele/base_potential.hpp"
+
 using pele::Array;
 
 class PotentialTest : public ::testing::Test {
-public:
-  std::shared_ptr<pele::BasePotential> pot; // this must be set manually
-  pele::Array<double> x;                    // this must be set manually
-  double etrue;                             // this must be set manually
+ public:
+  std::shared_ptr<pele::BasePotential> pot;  // this must be set manually
+  pele::Array<double> x;                     // this must be set manually
+  double etrue;                              // this must be set manually
   pele::Array<double> g, gnum, h, hnum;
 
   void test_energy() {
@@ -32,10 +32,9 @@ public:
     for (size_t k = 0; k < g.size(); ++k) {
       if (std::abs(g[k]) < 1e-10) {
         EXPECT_NEAR(g[k], gnum[k], 1e-6);
+      } else {
+        EXPECT_NEAR(g[k] / norm(g), gnum[k] / norm(gnum), 1e-6);
       }
-      else  {
-      EXPECT_NEAR(g[k]/norm(g), gnum[k]/norm(gnum), 1e-6);
-    }
     }
   }
 
@@ -53,17 +52,15 @@ public:
     for (size_t i = 0; i < g.size(); ++i) {
       if (std::abs(g[i]) < 1e-10) {
         EXPECT_NEAR(g[i], gnum[i], 1e-6);
-      }
-      else {
-        EXPECT_NEAR(g[i]/norm(g), gnum[i]/norm(gnum), 1e-6);
+      } else {
+        EXPECT_NEAR(g[i] / norm(g), gnum[i] / norm(gnum), 1e-6);
       }
     }
     for (size_t i = 0; i < h.size(); ++i) {
       if (std::abs(h[i]) < 1e-10) {
         EXPECT_NEAR(h[i], hnum[i], 1e-3);
-      }
-      else {
-        EXPECT_NEAR(h[i]/norm(h), hnum[i]/norm(hnum), 1e-3);
+      } else {
+        EXPECT_NEAR(h[i] / norm(h), hnum[i] / norm(hnum), 1e-3);
       }
     }
   }

--- a/cpp_tests/source/test_vecn.cpp
+++ b/cpp_tests/source/test_vecn.cpp
@@ -1,10 +1,11 @@
 #include <gtest/gtest.h>
-#include "pele/aatopology.hpp"
-#include "pele/matrix.hpp"
-#include "pele/vecn.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+
+#include "pele/aatopology.hpp"
+#include "pele/matrix.hpp"
+#include "pele/vecn.hpp"
 
 using pele::MatrixNM;
 using pele::VecN;
@@ -70,8 +71,7 @@ TEST(VecNTest, RangeBasedFor_Works) {
 TEST(VecNTest, SumOperator_VecN) {
   pele::VecN<3> v(-1);
   pele::VecN<3> v2(1);
-  for (size_t i = 0; i < v2.size(); ++i)
-    v2[i] = 1;
+  for (size_t i = 0; i < v2.size(); ++i) v2[i] = 1;
   v += v2;
   EXPECT_NE(v.data(), v2.data());
   for (int i = 0; i < 3; ++i) {

--- a/cpp_tests/source/test_wca.cpp
+++ b/cpp_tests/source/test_wca.cpp
@@ -1,4 +1,8 @@
+#include <cmath>
+#include <fstream>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <stdexcept>
 
 #include "pele/array.hpp"
 #include "pele/base_interaction.hpp"
@@ -8,13 +12,8 @@
 #include "pele/wca.hpp"
 #include "test_utils.hpp"
 
-#include <cmath>
-#include <fstream>
-#include <iostream>
-#include <stdexcept>
-
 static double const EPS = std::numeric_limits<double>::min();
-#define EXPECT_NEAR_RELATIVE(A, B, T)                                          \
+#define EXPECT_NEAR_RELATIVE(A, B, T) \
   EXPECT_NEAR(A / (fabs(A) + fabs(B) + EPS), B / (fabs(A) + fabs(B) + EPS), T)
 
 using pele::Array;
@@ -23,7 +22,7 @@ using pele::pos_int_pow;
 using pele::WCA;
 
 class WCATest : public PotentialTest {
-public:
+ public:
   double sig, eps;
   size_t natoms;
 
@@ -58,7 +57,7 @@ TEST_F(WCATest, EnergyGradientHessian_AgreesWithNumerical) {
 }
 
 class WCAAtomListTest : public WCATest {
-public:
+ public:
   virtual void setup_potential() {
     pele::Array<size_t> atoms(natoms);
     for (size_t i = 0; i < atoms.size(); ++i) {
@@ -81,7 +80,7 @@ TEST_F(WCAAtomListTest, EnergyGradientHessian_AgreesWithNumerical) {
  * HS_WCA tests
  */
 class HS_WCATest : public ::testing::Test {
-public:
+ public:
   double eps, sca, etrue;
   Array<double> x, g, gnum, radii;
   virtual void SetUp() {
@@ -115,10 +114,13 @@ TEST_F(HS_WCATest, Energy_Works) {
 }
 
 class OtherfHS_WCA {
-public:
+ public:
   OtherfHS_WCA(const double r_sum_, const double infinity_,
                const double epsilon_, const double alpha_)
-      : r_sum(r_sum_), infinity(infinity_), epsilon(epsilon_), alpha(alpha_),
+      : r_sum(r_sum_),
+        infinity(infinity_),
+        epsilon(epsilon_),
+        alpha(alpha_),
         r_sum_soft((1 + alpha) * r_sum) {}
   double operator()(const double r) const {
     if (r >= r_sum_soft) {
@@ -155,7 +157,7 @@ public:
     return sigma() / (pos_int_pow<2>(r) - pos_int_pow<2>(r_sum));
   }
 
-private:
+ private:
   const double r_sum;
   const double infinity;
   const double epsilon;
@@ -164,12 +166,16 @@ private:
 };
 
 class OthersfHS_WCA {
-public:
+ public:
   OthersfHS_WCA(const double r_sum_, const double epsilon_, const double alpha_,
                 const double delta_ = 1e-10)
-      : r_sum(r_sum_), epsilon(epsilon_), alpha(alpha_), delta(delta_),
+      : r_sum(r_sum_),
+        epsilon(epsilon_),
+        alpha(alpha_),
+        delta(delta_),
         fHS_WCA(r_sum, std::numeric_limits<double>::max(), epsilon, alpha),
-        r_sum_soft((1 + alpha) * r_sum), r_X(r_sum + delta) {}
+        r_sum_soft((1 + alpha) * r_sum),
+        r_X(r_sum + delta) {}
   double operator()(const double r) const {
     if (r > r_sum_soft) {
       return 0;
@@ -182,7 +188,7 @@ public:
     return fHS_WCA(r_X) + (r - r_X) * fHS_WCA.grad(r_X);
   }
 
-private:
+ private:
   const double r_sum;
   const double epsilon;
   const double alpha;
@@ -366,7 +372,7 @@ TEST_F(HS_WCATest, Norm_SimpleTest) {
 }
 
 class HS_WCA_StabilityTest : public ::testing::Test {
-public:
+ public:
   size_t nparticles;
   size_t ndim;
   size_t ndof;

--- a/examples/new_potential/cpp_potential/_mypotential.hpp
+++ b/examples/new_potential/cpp_potential/_mypotential.hpp
@@ -5,9 +5,10 @@
  *
  */
 
+#include <memory>
+
 #include "pele/distance.h"
 #include "pele/simple_pairwise_potential.h"
-#include <memory>
 
 namespace pele {
 
@@ -69,9 +70,9 @@ struct mypot_interaction {
  */
 class MyPot : public pele::SimplePairwisePotential<mypot_interaction,
                                                    cartesian_distance<3>> {
-public:
+ public:
   MyPot(double sig, double eps)
       : SimplePairwisePotential<mypot_interaction, cartesian_distance<3>>(
             std::make_shared<mypot_interaction>(sig, eps)) {}
 };
-} // namespace pele
+}  // namespace pele

--- a/pele/optimize/_gradient_descent_cpp.pyx
+++ b/pele/optimize/_gradient_descent_cpp.pyx
@@ -21,7 +21,7 @@ from libcpp.vector cimport vector
 # import the externally defined gradient descent implementation
 cdef extern from "pele/gradient_descent.hpp" namespace "pele":
     cdef cppclass cppGradientDescent "pele::GradientDescent":
-        cppGradientDescent(shared_ptr[_pele.cBasePotential], _pele.Array[double], double, double, bool) except +
+        cppGradientDescent(shared_ptr[_pele.cBasePotential], _pele.Array[double], double, double, bool, int) except +
         void set_tol(double) except +
         void set_maxstep(double) except +
         void set_max_iter(int) except +
@@ -39,7 +39,7 @@ cdef class _Cdef_GradientDescent_CPP(_pele_opt.GradientOptimizer):
 
     def __cinit__(self, potential, x0, double tol=1e-5, int iprint=-1,
                   energy=None, gradient=None,
-                  int nsteps=10000, int verbosity=0, events=None, logger=None, double stepsize = 0.005, bool save_trajectory=False):
+                  int nsteps=10000, int verbosity=0, events=None, logger=None, double stepsize = 0.005, bool save_trajectory=False, int iterations_before_save=1):
         potential = as_cpp_potential(potential, verbose=verbosity>0)
         self.pot = potential
         self.save_trajectory = save_trajectory
@@ -49,7 +49,7 @@ cdef class _Cdef_GradientDescent_CPP(_pele_opt.GradientOptimizer):
         self.thisptr = shared_ptr[_pele_opt.cGradientOptimizer]( <_pele_opt.cGradientOptimizer*>
                 new cppGradientDescent(self.pot.thisptr,
                              _pele.Array[double](<double*> x0c.data, x0c.size),
-                             tol, stepsize, save_trajectory))
+                             tol, stepsize, save_trajectory, iterations_before_save))
         cdef cppGradientDescent* gd_ptr = <cppGradientDescent*> self.thisptr.get()
         gd_ptr.set_max_iter(nsteps)
         gd_ptr.set_verbosity(verbosity)

--- a/pele/optimize/_modified_fire_cpp.pxd
+++ b/pele/optimize/_modified_fire_cpp.pxd
@@ -10,6 +10,6 @@ cdef extern from "pele/modified_fire.hpp" namespace "pele":
     cdef cppclass cppMODIFIED_FIRE "pele::MODIFIED_FIRE":
         cppMODIFIED_FIRE(shared_ptr[_pele.cBasePotential] , _pele.Array[double], 
                          double, double, double, size_t , double, double, 
-                         double, double, double, cbool, cbool) except +
+                         double, double, double, cbool, cbool, int) except +
         vector[double] get_time_trajectory() except +
         vector[double] get_gradient_norm_trajectory() except +

--- a/pele/optimize/_modified_fire_cpp.pyx
+++ b/pele/optimize/_modified_fire_cpp.pyx
@@ -31,12 +31,13 @@ cdef class _Cdef_MODIFIED_FIRE_CPP(_pele_opt.GradientOptimizer):
     cdef int nsteps
     cdef int verbosity
     cdef bool save_trajectory
+    cdef int iterations_before_save
     
     
     
     def __cinit__(self, x0, potential, double dtstart = 0.1, double dtmax = 1, double maxstep=0.5, size_t Nmin=5, double finc=1.1, 
                    double fdec=0.5, double fa=0.99, double astart=0.1, double tol=1e-3, bool stepback = True, 
-                   int iprint=-1, energy=None, gradient=None, int nsteps=10000, int verbosity=0, events = None, save_trajectory=False):
+                   int iprint=-1, energy=None, gradient=None, int nsteps=10000, int verbosity=0, events = None, save_trajectory=False, iterations_before_save=1):
         
         self.dtstart = dtstart
         self.dtmax = dtmax
@@ -52,6 +53,7 @@ cdef class _Cdef_MODIFIED_FIRE_CPP(_pele_opt.GradientOptimizer):
         self.nsteps = nsteps
         self.verbosity = verbosity
         self.save_trajectory = save_trajectory
+        self.iterations_before_save = iterations_before_save
         
         potential = as_cpp_potential(potential, verbose=verbosity>0)
         
@@ -60,7 +62,7 @@ cdef class _Cdef_MODIFIED_FIRE_CPP(_pele_opt.GradientOptimizer):
         self.x0 = x0c
         self.thisptr = shared_ptr[_pele_opt.cGradientOptimizer]( <_pele_opt.cGradientOptimizer*>
                         new cppMODIFIED_FIRE(pot.thisptr, _pele.Array[double](<double*> x0c.data, x0c.size),
-                                             dtstart, dtmax, maxstep, Nmin, finc, fdec, fa, astart, tol, stepback, save_trajectory))
+                                             dtstart, dtmax, maxstep, Nmin, finc, fdec, fa, astart, tol, stepback, save_trajectory, iterations_before_save))
         
         self.thisptr.get().set_max_iter(nsteps)
         self.thisptr.get().set_verbosity(verbosity)

--- a/pele/optimize/cvode_opt.pyx
+++ b/pele/optimize/cvode_opt.pyx
@@ -29,7 +29,7 @@ cdef extern from "pele/cvode.hpp" namespace "pele":
 cdef extern from "pele/cvode.hpp" namespace "pele":
     cdef cppclass cppCVODEBDFOptimizer "pele::CVODEBDFOptimizer":
         cppCVODEBDFOptimizer(shared_ptr[_pele.cBasePotential], _pele.Array[double],
-                             double, double, double, HessianType, bool, bool) except +
+                             double, double, double, HessianType, bool, bool, int) except +
         double get_nhev() except +
         vector[double] get_time_trajectory() except +
         vector[double] get_gradient_norm_trajectory() except +
@@ -43,7 +43,7 @@ cdef class _Cdef_CVODEBDFOptimizer_CPP(_pele_opt.GradientOptimizer):
     cdef _pele.BasePotential pot
     cdef HessianType hess_type
     cdef bool save_trajectory
-    def __cinit__(self, potential, x0,  double tol=1e-4, double rtol = 1e-4, double atol = 1e-4, int nsteps=10000, HessianType hessian_type=HessianType.DENSE, bool use_newton_stop_criterion=False, bool save_trajectory=False):
+    def __cinit__(self, potential, x0,  double tol=1e-4, double rtol = 1e-4, double atol = 1e-4, int nsteps=10000, HessianType hessian_type=HessianType.DENSE, bool use_newton_stop_criterion=False, bool save_trajectory=False, int iterations_before_save=1):
         potential = as_cpp_potential(potential, verbose=True)
 
         self.pot = potential
@@ -53,7 +53,7 @@ cdef class _Cdef_CVODEBDFOptimizer_CPP(_pele_opt.GradientOptimizer):
         self.thisptr = shared_ptr[_pele_opt.cGradientOptimizer]( <_pele_opt.cGradientOptimizer*>
                 new cppCVODEBDFOptimizer(self.pot.thisptr,
                              _pele.Array[double](<double*> x0c.data, x0c.size),
-                                tol, rtol, atol, hess_type, use_newton_stop_criterion, save_trajectory))
+                                tol, rtol, atol, hess_type, use_newton_stop_criterion, save_trajectory, iterations_before_save))
     
     def get_result(self):
         cdef cppCVODEBDFOptimizer* cvode_ptr = <cppCVODEBDFOptimizer*> self.thisptr.get()

--- a/pele/optimize/tests/test_cvode.py
+++ b/pele/optimize/tests/test_cvode.py
@@ -1,5 +1,7 @@
-"""
-Tests whether the CVODE results through the python wrapper match with the C++ results.
+"""Test for CVODE.
+
+Tests whether the CVODE results through the python wrapper match with the C++
+results.
 
 TODO: The results are hardcoded for the current test_cvode.py.
       We need to later ensure that we automate the comparison.

--- a/pele/optimize/tests/test_save_trajectory.py
+++ b/pele/optimize/tests/test_save_trajectory.py
@@ -1,0 +1,103 @@
+"""Test saving the trajectory data.
+
+Tests for saving the trajectory data with three different optimizers
+for which this is currently implemented,
+1. Modified FIRE
+2. CVODE
+3. Gradient Descent
+
+All three optimizers derive from the ODEBasedOptimizer class.
+"""
+
+from pele.optimize import (
+    CVODEBDFOptimizer,
+    GradientDescent_CPP,
+    ModifiedFireCPP,
+)
+
+from .potential_fixture import potential_initial_and_final_conditions
+
+
+def test_trajectory_saving_works_every_step(
+    potential_initial_and_final_conditions,
+):
+    """Test that the trajectory is saved every step."""
+    (
+        potential,
+        initial_coordinates,
+        _,
+        _,
+    ) = potential_initial_and_final_conditions
+
+    cvode = CVODEBDFOptimizer(
+        potential,
+        initial_coordinates,
+        save_trajectory=True,
+        iterations_before_save=1,
+    )
+    fire = ModifiedFireCPP(
+        initial_coordinates,
+        potential,
+        save_trajectory=True,
+        iterations_before_save=1,
+    )
+    gradient_descent = GradientDescent_CPP(
+        potential,
+        initial_coordinates,
+        save_trajectory=True,
+        iterations_before_save=1,
+    )
+
+    optimizer_dict = {
+        "cvode": cvode,
+        "fire": fire,
+        "gradient_descent": gradient_descent,
+    }
+
+    for key, optimizer in optimizer_dict.items():
+        print("Testing optimizer: ", key)
+        res = optimizer.run(100)
+        assert len(res.time_trajectory) == res.nsteps
+        assert len(res.gradient_norm_trajectory) == res.nsteps
+
+
+def test_skipping_trajectory_saving(potential_initial_and_final_conditions):
+    """Test that the trajectory saving when saving is skipped."""
+    (
+        potential,
+        initial_coordinates,
+        _,
+        _,
+    ) = potential_initial_and_final_conditions
+
+    skip = 10
+    cvode = CVODEBDFOptimizer(
+        potential,
+        initial_coordinates,
+        save_trajectory=True,
+        iterations_before_save=skip,
+    )
+    fire = ModifiedFireCPP(
+        initial_coordinates,
+        potential,
+        save_trajectory=True,
+        iterations_before_save=skip,
+    )
+    gradient_descent = GradientDescent_CPP(
+        potential,
+        initial_coordinates,
+        save_trajectory=True,
+        iterations_before_save=skip,
+    )
+
+    optimizer_dict = {
+        "cvode": cvode,
+        "fire": fire,
+        "gradient_descent": gradient_descent,
+    }
+
+    for key, optimizer in optimizer_dict.items():
+        print("Testing optimizer: ", key)
+        res = optimizer.run(100)
+        assert len(res.time_trajectory) == res.nsteps // skip
+        assert len(res.gradient_norm_trajectory) == res.nsteps // skip

--- a/playground/native_code/neb.cpp
+++ b/playground/native_code/neb.cpp
@@ -42,4 +42,4 @@ void NEB::interpolate(Array &x1, Array &x2, Array &xout, double t) {
 void test_array(Array a) { std::cout << a << std::endl; }
 
 void test_py(void) { std::cout << "hello world\n"; }
-} // namespace pele
+}  // namespace pele

--- a/playground/native_code/old_c_lbfgs/lbfgs_wrapper.cpp
+++ b/playground/native_code/old_c_lbfgs/lbfgs_wrapper.cpp
@@ -1,18 +1,19 @@
-#include "potential.h"
 #include <iostream>
 #include <lbfgs.h>
 #include <stdio.h>
 #include <string>
 
+#include "potential.h"
+
 namespace pele {
 
 class LBFGS {
-protected:
+ protected:
   Potential *_pot;
   lbfgs_parameter_t _params;
   int _error_code;
 
-public:
+ public:
   LBFGS() : _pot(NULL) { setup(); }
   LBFGS(Potential *pot) : _pot(pot) { setup(); }
 
@@ -30,79 +31,79 @@ public:
 
   const char *error_string() {
     switch (_error_code) {
-    case LBFGS_SUCCESS:
-      return "LBFGS_SUCCESS";
-    // case LBFGS_CONVERGENCE: return "LBFGS_CONVERGENCE";
-    case LBFGS_STOP:
-      return "LBFGS_STOP";
-    case LBFGS_ALREADY_MINIMIZED:
-      return "LBFGS_ALREADY_MINIMIZED";
-    case LBFGSERR_UNKNOWNERROR:
-      return "LBFGSERR_UNKNOWNERROR";
-    case LBFGSERR_LOGICERROR:
-      return "LBFGSERR_LOGICERROR";
-    case LBFGSERR_OUTOFMEMORY:
-      return "LBFGSERR_OUTOFMEMORY";
-    case LBFGSERR_CANCELED:
-      return "LBFGSERR_CANCELED";
-    case LBFGSERR_INVALID_N:
-      return "LBFGSERR_INVALID_N";
-    case LBFGSERR_INVALID_N_SSE:
-      return "LBFGSERR_INVALID_N_SSE";
-    case LBFGSERR_INVALID_X_SSE:
-      return "LBFGSERR_INVALID_X_SSE";
-    case LBFGSERR_INVALID_EPSILON:
-      return "LBFGSERR_INVALID_EPSILON";
-    case LBFGSERR_INVALID_TESTPERIOD:
-      return "LBFGSERR_INVALID_TESTPERIOD";
-    case LBFGSERR_INVALID_DELTA:
-      return "LBFGSERR_INVALID_DELTA";
-    case LBFGSERR_INVALID_LINESEARCH:
-      return "LBFGSERR_INVALID_LINESEARCH";
-    case LBFGSERR_INVALID_MINSTEP:
-      return "LBFGSERR_INVALID_MINSTEP";
-    case LBFGSERR_INVALID_MAXSTEP:
-      return "LBFGSERR_INVALID_MAXSTEP";
-    case LBFGSERR_INVALID_FTOL:
-      return "LBFGSERR_INVALID_FTOL";
-    case LBFGSERR_INVALID_WOLFE:
-      return "LBFGSERR_INVALID_WOLFE";
-    case LBFGSERR_INVALID_GTOL:
-      return "LBFGSERR_INVALID_GTOL";
-    case LBFGSERR_INVALID_XTOL:
-      return "LBFGSERR_INVALID_XTOL";
-    case LBFGSERR_INVALID_MAXLINESEARCH:
-      return "LBFGSERR_INVALID_MAXLINESEARCH";
-    case LBFGSERR_INVALID_ORTHANTWISE:
-      return "LBFGSERR_INVALID_ORTHANTWISE";
-    case LBFGSERR_INVALID_ORTHANTWISE_START:
-      return "LBFGSERR_INVALID_ORTHANTWISE_START";
-    case LBFGSERR_INVALID_ORTHANTWISE_END:
-      return "LBFGSERR_INVALID_ORTHANTWISE_END";
-    case LBFGSERR_OUTOFINTERVAL:
-      return "LBFGSERR_OUTOFINTERVAL";
-    case LBFGSERR_INCORRECT_TMINMAX:
-      return "LBFGSERR_INCORRECT_TMINMAX";
-    case LBFGSERR_ROUNDING_ERROR:
-      return "LBFGSERR_ROUNDING_ERROR";
-    case LBFGSERR_MINIMUMSTEP:
-      return "LBFGSERR_MINIMUMSTEP";
-    case LBFGSERR_MAXIMUMSTEP:
-      return "LBFGSERR_MAXIMUMSTEP";
-    case LBFGSERR_MAXIMUMLINESEARCH:
-      return "LBFGSERR_MAXIMUMLINESEARCH";
-    case LBFGSERR_MAXIMUMITERATION:
-      return "LBFGSERR_MAXIMUMITERATION";
-    case LBFGSERR_WIDTHTOOSMALL:
-      return "LBFGSERR_WIDTHTOOSMALL";
-    case LBFGSERR_INVALIDPARAMETERS:
-      return "LBFGSERR_INVALIDPARAMETERS";
-    case LBFGSERR_INCREASEGRADIENT:
-      return "LBFGSERR_INCREASEGRADIENT";
+      case LBFGS_SUCCESS:
+        return "LBFGS_SUCCESS";
+      // case LBFGS_CONVERGENCE: return "LBFGS_CONVERGENCE";
+      case LBFGS_STOP:
+        return "LBFGS_STOP";
+      case LBFGS_ALREADY_MINIMIZED:
+        return "LBFGS_ALREADY_MINIMIZED";
+      case LBFGSERR_UNKNOWNERROR:
+        return "LBFGSERR_UNKNOWNERROR";
+      case LBFGSERR_LOGICERROR:
+        return "LBFGSERR_LOGICERROR";
+      case LBFGSERR_OUTOFMEMORY:
+        return "LBFGSERR_OUTOFMEMORY";
+      case LBFGSERR_CANCELED:
+        return "LBFGSERR_CANCELED";
+      case LBFGSERR_INVALID_N:
+        return "LBFGSERR_INVALID_N";
+      case LBFGSERR_INVALID_N_SSE:
+        return "LBFGSERR_INVALID_N_SSE";
+      case LBFGSERR_INVALID_X_SSE:
+        return "LBFGSERR_INVALID_X_SSE";
+      case LBFGSERR_INVALID_EPSILON:
+        return "LBFGSERR_INVALID_EPSILON";
+      case LBFGSERR_INVALID_TESTPERIOD:
+        return "LBFGSERR_INVALID_TESTPERIOD";
+      case LBFGSERR_INVALID_DELTA:
+        return "LBFGSERR_INVALID_DELTA";
+      case LBFGSERR_INVALID_LINESEARCH:
+        return "LBFGSERR_INVALID_LINESEARCH";
+      case LBFGSERR_INVALID_MINSTEP:
+        return "LBFGSERR_INVALID_MINSTEP";
+      case LBFGSERR_INVALID_MAXSTEP:
+        return "LBFGSERR_INVALID_MAXSTEP";
+      case LBFGSERR_INVALID_FTOL:
+        return "LBFGSERR_INVALID_FTOL";
+      case LBFGSERR_INVALID_WOLFE:
+        return "LBFGSERR_INVALID_WOLFE";
+      case LBFGSERR_INVALID_GTOL:
+        return "LBFGSERR_INVALID_GTOL";
+      case LBFGSERR_INVALID_XTOL:
+        return "LBFGSERR_INVALID_XTOL";
+      case LBFGSERR_INVALID_MAXLINESEARCH:
+        return "LBFGSERR_INVALID_MAXLINESEARCH";
+      case LBFGSERR_INVALID_ORTHANTWISE:
+        return "LBFGSERR_INVALID_ORTHANTWISE";
+      case LBFGSERR_INVALID_ORTHANTWISE_START:
+        return "LBFGSERR_INVALID_ORTHANTWISE_START";
+      case LBFGSERR_INVALID_ORTHANTWISE_END:
+        return "LBFGSERR_INVALID_ORTHANTWISE_END";
+      case LBFGSERR_OUTOFINTERVAL:
+        return "LBFGSERR_OUTOFINTERVAL";
+      case LBFGSERR_INCORRECT_TMINMAX:
+        return "LBFGSERR_INCORRECT_TMINMAX";
+      case LBFGSERR_ROUNDING_ERROR:
+        return "LBFGSERR_ROUNDING_ERROR";
+      case LBFGSERR_MINIMUMSTEP:
+        return "LBFGSERR_MINIMUMSTEP";
+      case LBFGSERR_MAXIMUMSTEP:
+        return "LBFGSERR_MAXIMUMSTEP";
+      case LBFGSERR_MAXIMUMLINESEARCH:
+        return "LBFGSERR_MAXIMUMLINESEARCH";
+      case LBFGSERR_MAXIMUMITERATION:
+        return "LBFGSERR_MAXIMUMITERATION";
+      case LBFGSERR_WIDTHTOOSMALL:
+        return "LBFGSERR_WIDTHTOOSMALL";
+      case LBFGSERR_INVALIDPARAMETERS:
+        return "LBFGSERR_INVALIDPARAMETERS";
+      case LBFGSERR_INCREASEGRADIENT:
+        return "LBFGSERR_INCREASEGRADIENT";
     }
   }
 
-protected:
+ protected:
   void setup(void) {
     lbfgs_parameter_init(&_params);
     //_params.max_step=0.1;
@@ -140,4 +141,4 @@ protected:
                                                          step, n, k, ls);
   }
 };
-} // namespace pele
+}  // namespace pele

--- a/source/aatopology.cpp
+++ b/source/aatopology.cpp
@@ -1,12 +1,12 @@
 #include "pele/aatopology.hpp"
+
 #include "pele/rotations.hpp"
 #include "pele/vecn.hpp"
 
 namespace pele {
 
-pele::Array<double>
-pele::RigidFragment::to_atomistic(pele::Array<double> const com,
-                                  pele::VecN<3> const &p) {
+pele::Array<double> pele::RigidFragment::to_atomistic(
+    pele::Array<double> const com, pele::VecN<3> const &p) {
   assert(com.size() == _ndim);
   assert(p.size() == 3);
   auto rmat = pele::aa_to_rot_mat(p);
@@ -217,9 +217,8 @@ void pele::RBTopology::transform_gradient(pele::Array<double> rbcoords,
   }
 }
 
-pele::VecN<3>
-pele::RBTopology::align_angle_axis_vectors(pele::VecN<3> const &p1,
-                                           pele::VecN<3> const &p2in) {
+pele::VecN<3> pele::RBTopology::align_angle_axis_vectors(
+    pele::VecN<3> const &p1, pele::VecN<3> const &p2in) {
   pele::VecN<3> p2 = p2in;
   pele::VecN<3> n2, p2n;
   if (norm<3>(p2) < 1e-6) {
@@ -307,4 +306,4 @@ void pele::TransformAACluster::rotate(pele::Array<double> x,
   }
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/atlj.cpp
+++ b/source/atlj.cpp
@@ -19,8 +19,11 @@
 namespace pele {
 
 ATLJ::ATLJ(double sig, double eps, double Z)
-    : m_eps(eps), m_sig(sig), m_Z(Z),
-      ljpot(4 * eps * pow(sig, 6), 4 * eps * pow(sig, 12)), m_natoms(3),
+    : m_eps(eps),
+      m_sig(sig),
+      m_Z(Z),
+      ljpot(4 * eps * pow(sig, 6), 4 * eps * pow(sig, 12)),
+      m_natoms(3),
       m_ndim(3)
 
 {}
@@ -54,4 +57,4 @@ double ATLJ::get_axilrod_teller_energy(const Array<double> &x) {
   return energy;
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/backtracking.cpp
+++ b/source/backtracking.cpp
@@ -1,7 +1,4 @@
 #include "pele/backtracking.hpp"
-#include "pele/array.hpp"
-#include "pele/base_potential.hpp"
-#include "pele/lsparameters.hpp"
 #include <cmath>
 #include <complex>
 #include <iomanip>
@@ -9,12 +6,15 @@
 #include <pele/eigen_interface.hpp>
 #include <stdexcept>
 
+#include "pele/array.hpp"
+#include "pele/base_potential.hpp"
+#include "pele/lsparameters.hpp"
+
 using namespace std;
 namespace pele {
 
 double BacktrackingLineSearch::line_search(Array<double> &x,
                                            Array<double> step) {
-
   eig_eq_pele(xoldvec, xold_);
   eig_eq_pele(gradvec, gold_);
   Scalar stpsize = initial_stpsize;
@@ -31,10 +31,10 @@ double BacktrackingLineSearch::line_search(Array<double> &x,
   // start with the initial stepsize
 
   step_moving_away_from_min =
-      false; // only true when step is opposite to gradient
+      false;  // only true when step is opposite to gradient
   LSFunc(f, xvec, gradvec, stpsize, step_direction, xoldvec, params);
   if (step_moving_away_from_min) {
-    return 0; // Line search will not work
+    return 0;  // Line search will not work
   }
   pele_eq_eig(x, xvec);
   pele_eq_eig(g_, gradvec);
@@ -75,14 +75,12 @@ double BacktrackingLineSearch::func_grad_wrapper(Vector &x, Vector &grad) {
 void BacktrackingLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
                                     Scalar &step, const Vector &drt,
                                     const Vector &xp, const LBFGSParam &param) {
-
   // Decreasing and increasing factors
   const Scalar dec = 0.5;
   const Scalar inc = 2.1;
 
   // Check the value of step
-  if (step <= Scalar(0))
-    std::invalid_argument("'step' must be positive");
+  if (step <= Scalar(0)) std::invalid_argument("'step' must be positive");
 
   // Save the function value at the current x
   const Scalar fx_init = fx;
@@ -95,7 +93,7 @@ void BacktrackingLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
 #endif
   // Make sure d points to a descent direction
   if (dg_init > 0) {
-    step_moving_away_from_min = true; // step points away from minimum
+    step_moving_away_from_min = true;  // step points away from minimum
     return;
   }
   const Scalar test_decr = param.ftol * dg_init;
@@ -129,4 +127,4 @@ void BacktrackingLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
   }
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/bracketing.cpp
+++ b/source/bracketing.cpp
@@ -3,7 +3,6 @@
 namespace pele {
 
 double BracketingLineSearch::line_search(Array<double> &x, Array<double> step) {
-
   eig_eq_pele(xoldvec, xold_);
   eig_eq_pele(gradvec, gold_);
 
@@ -43,8 +42,7 @@ void BracketingLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
                                   Scalar &step, const Vector &drt,
                                   const Vector &xp, const LBFGSParam &param) {
   // Check the value of step
-  if (step <= Scalar(0))
-    throw std::invalid_argument("'step' must be positive");
+  if (step <= Scalar(0)) throw std::invalid_argument("'step' must be positive");
 
   // Save the function value at the current x
   const Scalar fx_init = fx;
@@ -70,16 +68,14 @@ void BracketingLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
       step_hi = step;
     } else {
       // Armijo condition is met
-      if (param.linesearch == LINESEARCH_BACKTRACKING_ARMIJO)
-        break;
+      if (param.linesearch == LINESEARCH_BACKTRACKING_ARMIJO) break;
 
       const Scalar dg = grad.dot(drt);
       if (dg < param.wolfe * dg_init) {
         step_lo = step;
       } else {
         // Regular Wolfe condition is met
-        if (param.linesearch == LINESEARCH_BACKTRACKING_WOLFE)
-          break;
+        if (param.linesearch == LINESEARCH_BACKTRACKING_WOLFE) break;
 
         if (dg > -param.wolfe * dg_init) {
           step_hi = step;
@@ -109,4 +105,4 @@ void BracketingLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
   }
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/cvode.cpp
+++ b/source/cvode.cpp
@@ -33,8 +33,9 @@ CVODEBDFOptimizer::CVODEBDFOptimizer(
     std::shared_ptr<pele::BasePotential> potential,
     const pele::Array<double> x0, double tol, double rtol, double atol,
     HessianType hessian_type, bool use_newton_stop_criterion,
-    bool save_trajectory)
-    : ODEBasedOptimizer(potential, x0, tol, save_trajectory),
+    bool save_trajectory, int iterations_before_save)
+    : ODEBasedOptimizer(potential, x0, tol, save_trajectory,
+                        iterations_before_save),
       N_size(x0.size()),
       tN(1.0),
       ret(0),

--- a/source/cvode.cpp
+++ b/source/cvode.cpp
@@ -1,4 +1,14 @@
 #include "pele/cvode.hpp"
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <stdio.h>
+#include <sundials/sundials_context.h>
+#include <sundials/sundials_matrix.h>
 
 #include "cvode/cvode.h"
 #include "cvode/cvode_ls.h"
@@ -10,16 +20,6 @@
 #include "sundials/sundials_linearsolver.h"
 #include "sundials/sundials_nvector.h"
 #include "sunmatrix/sunmatrix_dense.h"
-#include <cassert>
-#include <cmath>
-#include <cstddef>
-#include <iomanip>
-#include <iostream>
-#include <memory>
-#include <ostream>
-#include <stdio.h>
-#include <sundials/sundials_context.h>
-#include <sundials/sundials_matrix.h>
 //#include <hoomd/HOOMDMath.h>
 
 using namespace std;
@@ -32,10 +32,16 @@ namespace pele {
 CVODEBDFOptimizer::CVODEBDFOptimizer(
     std::shared_ptr<pele::BasePotential> potential,
     const pele::Array<double> x0, double tol, double rtol, double atol,
-    HessianType hessian_type, bool use_newton_stop_criterion, bool save_trajectory)
-    : ODEBasedOptimizer(potential, x0, tol, save_trajectory), N_size(x0.size()),
-      tN(1.0), ret(0), hessian(x0.size(), x0.size()),
-      rtol_(rtol), atol_(atol), hessian_type_(hessian_type),
+    HessianType hessian_type, bool use_newton_stop_criterion,
+    bool save_trajectory)
+    : ODEBasedOptimizer(potential, x0, tol, save_trajectory),
+      N_size(x0.size()),
+      tN(1.0),
+      ret(0),
+      hessian(x0.size(), x0.size()),
+      rtol_(rtol),
+      atol_(atol),
+      hessian_type_(hessian_type),
       use_newton_stop_criterion_(use_newton_stop_criterion) {
   setup_cvode();
 };
@@ -56,7 +62,7 @@ void CVODEBDFOptimizer::setup_cvode() {
   std::cout << "tol: " << tol_ << std::endl;
   std::cout << "rtol: " << rtol_ << std::endl;
   std::cout << "atol: " << atol_ << std::endl;
-  switch(hessian_type_) {
+  switch (hessian_type_) {
     case HessianType::DENSE:
       std::cout << "hessian_type: DENSE" << std::endl;
       break;
@@ -122,7 +128,6 @@ void CVODEBDFOptimizer::setup_cvode() {
     }
 
   } else if (hessian_type_ == DENSE) {
-
     A = SUNDenseMatrix(N_size, N_size, sunctx);
     if (check_sundials_retval((void *)A, "SUNDenseMatrix", 0)) {
       throw std::runtime_error("SUNDenseMatrix failed");
@@ -204,14 +209,13 @@ void CVODEBDFOptimizer::one_iteration() {
 
 #if PRINT_TO_FILE == 1
   trajectory_file << std::setprecision(17) << x_;
-  time_file << std::setprecision(17) << time_ << std::endl;\
+  time_file << std::setprecision(17) << time_ << std::endl;
   gradient_file << std::setprecision(17) << g_;
 #endif
 }
 
 void CVODEBDFOptimizer::add_translation_offset_2d(Eigen::MatrixXd &hessian,
                                                   double offset) {
-
   // factor so that the added translation operators are unitary
   double factor = 2.0 / hessian.rows();
   offset = offset * factor;
@@ -348,7 +352,6 @@ int Jac(realtype t, N_Vector y, N_Vector fy, SUNMatrix J, void *user_data,
   return 0;
 };
 
-
 /**
  * @brief Checks sundials error code and prints out error message. Copied from
  * the sundials examples. Honestly this is 3 functions in one. it needs to be
@@ -360,7 +363,6 @@ int Jac(realtype t, N_Vector y, N_Vector fy, SUNMatrix J, void *user_data,
  */
 static int check_sundials_retval(void *return_value, const char *funcname,
                                  int opt) {
-
   int *retval;
 
   /* Check if SUNDIALS function returned NULL pointer - no memory allocated */
@@ -393,4 +395,4 @@ static int check_sundials_retval(void *return_value, const char *funcname,
   return (0);
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/generic_mixed_descent.cpp
+++ b/source/generic_mixed_descent.cpp
@@ -17,7 +17,6 @@
 using namespace std;
 namespace pele {
 bool GenericMixedDescent::x_in_convex_region() {
-
   x_.assign(opt_non_convex_->get_x());
   // Calculate hessian at x. Current version is hessian based.
   // Ideally you should be able to get the pointer to the hessian from the
@@ -34,8 +33,8 @@ bool GenericMixedDescent::x_in_convex_region() {
   hessian_copy_for_cholesky_data = hessian_copy_for_cholesky_.data();
   int info = 0;
   dpotrf_(&uplo, &N_int, hessian_copy_for_cholesky_data, &N_int, &info
-#ifdef LAPACK_FORTRAN_STRLEN_END // 1 is the length of the uplo string,
-                                 // necessary for current fortran
+#ifdef LAPACK_FORTRAN_STRLEN_END  // 1 is the length of the uplo string,
+                                  // necessary for current fortran
           ,
           1
 #endif
@@ -113,7 +112,6 @@ void GenericMixedDescent::one_iteration() {
  */
 void GenericMixedDescent::add_translation_offset_2d(Eigen::MatrixXd &hessian,
                                                     double offset) {
-
   // factor so that the added translation operators are unitary
   double factor = 2.0 / hessian.rows();
   offset = offset * factor;
@@ -129,4 +127,4 @@ void GenericMixedDescent::add_translation_offset_2d(Eigen::MatrixXd &hessian,
   // add the diagonal elements that were missed by the previous loop
   hessian.diagonal().array() += offset;
 }
-} // namespace pele
+}  // namespace pele

--- a/source/lbfgs.cpp
+++ b/source/lbfgs.cpp
@@ -1,18 +1,26 @@
 #include "pele/lbfgs.hpp"
-#include "pele/array.hpp"
-#include "pele/optimizer.hpp"
 #include <iostream>
 #include <limits>
 #include <memory>
+
+#include "pele/array.hpp"
+#include "pele/optimizer.hpp"
 
 namespace pele {
 
 LBFGS::LBFGS(std::shared_ptr<pele::BasePotential> potential,
              const pele::Array<double> x0, double tol, int M)
-    : GradientOptimizer(potential, x0, tol), M_(M), max_f_rise_(1e-4),
-      use_relative_f_(false), rho_(M_), H0_(0.1), k_(0), alpha(M_),
-      xold(x_.size()), gold(x_.size()), step(x_.size()) {
-
+    : GradientOptimizer(potential, x0, tol),
+      M_(M),
+      max_f_rise_(1e-4),
+      use_relative_f_(false),
+      rho_(M_),
+      H0_(0.1),
+      k_(0),
+      alpha(M_),
+      xold(x_.size()),
+      gold(x_.size()),
+      step(x_.size()) {
 #if PRINT_TO_FILE == 1
   trajectory_file.open("trajectory_lbfgs.txt");
 #endif
@@ -46,8 +54,9 @@ void LBFGS::one_iteration() {
 
   // print some status information
   if ((iprint_ > 0) && (iter_number_ % iprint_ == 0)) {
-    std::cout << "lbgs: " << iter_number_ << " E " << f_ << " rms " << gradient_norm_
-              << " nfev " << nfev_ << " step norm " << stepnorm << std::endl;
+    std::cout << "lbgs: " << iter_number_ << " E " << f_ << " rms "
+              << gradient_norm_ << " nfev " << nfev_ << " step norm "
+              << stepnorm << std::endl;
   }
   iter_number_ += 1;
 #if PRINT_TO_FILE == 1
@@ -143,13 +152,13 @@ void LBFGS::compute_lbfgs_step(Array<double> step) {
 #pragma simd reduction(+ : beta)
     for (size_t j2 = 0; j2 < step.size(); ++j2) {
       beta -= rho_[i] * y_[i * step.size() + j2] *
-              step[j2]; // -= due to inverted step
+              step[j2];  // -= due to inverted step
     }
     double alpha_beta = alpha[i] - beta;
 #pragma simd
     for (size_t j2 = 0; j2 < step.size(); ++j2) {
       step[j2] -=
-          s_[i * step.size() + j2] * alpha_beta; // -= due to inverted step
+          s_[i * step.size() + j2] * alpha_beta;  // -= due to inverted step
     }
   }
 }
@@ -220,8 +229,9 @@ double LBFGS::backtracking_linesearch(Array<double> step) {
 
 void LBFGS::reset(pele::Array<double> &x0) {
   if (x0.size() != x_.size()) {
-    throw std::invalid_argument("The number of degrees of freedom (x0.size()) "
-                                "cannot change when calling reset()");
+    throw std::invalid_argument(
+        "The number of degrees of freedom (x0.size()) "
+        "cannot change when calling reset()");
   }
   k_ = 0;
   iter_number_ = 0;
@@ -229,4 +239,4 @@ void LBFGS::reset(pele::Array<double> &x0) {
   x_.assign(x0);
   func_initialized_ = false;
 }
-} // namespace pele
+}  // namespace pele

--- a/source/linesearch.cpp
+++ b/source/linesearch.cpp
@@ -70,4 +70,4 @@ double OldLineSearch::line_search(Array<double> &x, Array<double> step) {
   return stepnorm * factor;
 };
 
-} // namespace pele
+}  // namespace pele

--- a/source/modified_fire.cpp
+++ b/source/modified_fire.cpp
@@ -45,8 +45,10 @@ MODIFIED_FIRE::MODIFIED_FIRE(std::shared_ptr<pele::BasePotential> potential,
                              pele::Array<double> &x0, double dtstart,
                              double dtmax, double maxstep, size_t Nmin,
                              double finc, double fdec, double fa, double astart,
-                             double tol, bool stepback, bool save_trajectory)
-    : ODEBasedOptimizer(potential, x0, tol, save_trajectory),
+                             double tol, bool stepback, bool save_trajectory,
+                             int iterations_before_save)
+    : ODEBasedOptimizer(potential, x0, tol, save_trajectory,
+                        iterations_before_save),
       _dtstart(dtstart),
       _dt(dtstart),
       _dtmax(dtmax),

--- a/source/modified_fire.cpp
+++ b/source/modified_fire.cpp
@@ -46,13 +46,27 @@ MODIFIED_FIRE::MODIFIED_FIRE(std::shared_ptr<pele::BasePotential> potential,
                              double dtmax, double maxstep, size_t Nmin,
                              double finc, double fdec, double fa, double astart,
                              double tol, bool stepback, bool save_trajectory)
-    : ODEBasedOptimizer(potential, x0,
-                        tol, save_trajectory),
-      _dtstart(dtstart), _dt(dtstart), _dtmax(dtmax), _maxstep(maxstep),
-      _Nmin(Nmin), _finc(finc), _fdec(fdec), _fa(fa), _astart(astart),
-      _a(astart), _fold(f_), _ifnorm(0), _vnorm(0), _v(x0.size(), 0),
-      _dx(x0.size()), _xold(x0.copy()), _gold(g_.copy()), _fire_iter_number(0),
-      _N(x_.size()), _stepback(stepback) {
+    : ODEBasedOptimizer(potential, x0, tol, save_trajectory),
+      _dtstart(dtstart),
+      _dt(dtstart),
+      _dtmax(dtmax),
+      _maxstep(maxstep),
+      _Nmin(Nmin),
+      _finc(finc),
+      _fdec(fdec),
+      _fa(fa),
+      _astart(astart),
+      _a(astart),
+      _fold(f_),
+      _ifnorm(0),
+      _vnorm(0),
+      _v(x0.size(), 0),
+      _dx(x0.size()),
+      _xold(x0.copy()),
+      _gold(g_.copy()),
+      _fire_iter_number(0),
+      _N(x_.size()),
+      _stepback(stepback) {
 #if PRINT_TO_FILE == 1
   trajectory_file.open("trajectory_modified_fire.txt");
   time_file.open("time_modified_fire.txt");
@@ -78,11 +92,11 @@ MODIFIED_FIRE::MODIFIED_FIRE(std::shared_ptr<pele::BasePotential> potential,
  */
 
 void MODIFIED_FIRE::initialize_func_gradient() {
-  nfev_ += 1; // this accounts for the energy evaluation done by the integrator
+  nfev_ += 1;  // this accounts for the energy evaluation done by the integrator
   f_ = potential_->get_energy_gradient(x_, g_);
   _fold = f_;
   for (size_t k = 0; k < x_.size();
-       ++k) { // set initial velocities (using forward Euler)
+       ++k) {  // set initial velocities (using forward Euler)
     _v[k] = -g_[k] * _dt;
   }
   _ifnorm = 1. / norm(g_);
@@ -105,7 +119,7 @@ void MODIFIED_FIRE::set_func_gradient(double f, Array<double> grad) {
   _fold = f_;
   g_.assign(grad);
   for (size_t k = 0; k < x_.size();
-       ++k) { // set initial velocities (using forward Euler)
+       ++k) {  // set initial velocities (using forward Euler)
     _v[k] = -g_[k] * _dt;
   }
   _ifnorm = 1. / norm(g_);
@@ -113,4 +127,4 @@ void MODIFIED_FIRE::set_func_gradient(double f, Array<double> grad) {
   gradient_norm_ = 1. / (_ifnorm * sqrt(_N));
   func_initialized_ = true;
 }
-} // namespace pele
+}  // namespace pele

--- a/source/more_thuente.cpp
+++ b/source/more_thuente.cpp
@@ -85,27 +85,20 @@ int MoreThuente::cvsrch(vector_t &x, scalar_t f, vector_t &g, scalar_t &stp,
     scalar_t dg = dot(g, s);
     scalar_t ftest1 = finit + stp * dgtest;
     // all possible convergence tests
-    if ((brackt & ((stp <= stmin) | (stp >= stmax))) | (infoc == 0))
-      info = 6;
+    if ((brackt & ((stp <= stmin) | (stp >= stmax))) | (infoc == 0)) info = 6;
 
-    if ((stp == stpmax) & (f <= ftest1) & (dg <= dgtest))
-      info = 5;
+    if ((stp == stpmax) & (f <= ftest1) & (dg <= dgtest)) info = 5;
 
-    if ((stp == stpmin) & ((f > ftest1) | (dg >= dgtest)))
-      info = 4;
+    if ((stp == stpmin) & ((f > ftest1) | (dg >= dgtest))) info = 4;
 
-    if (nfev >= maxfev)
-      info = 3;
+    if (nfev >= maxfev) info = 3;
 
-    if (brackt & (stmax - stmin <= xtol * stmax))
-      info = 2;
+    if (brackt & (stmax - stmin <= xtol * stmax)) info = 2;
 
-    if ((f <= ftest1) & (fabs(dg) <= gtol * (-dginit)))
-      info = 1;
+    if ((f <= ftest1) & (fabs(dg) <= gtol * (-dginit))) info = 1;
 
     // terminate when convergence reached
-    if (info != 0)
-      return -1;
+    if (info != 0) return -1;
 
     if (stage1 & (f <= ftest1) &
         (dg >= std::min<scalar_t>(ftol, gtol) * dginit))
@@ -133,8 +126,7 @@ int MoreThuente::cvsrch(vector_t &x, scalar_t f, vector_t &g, scalar_t &stp,
     }
 
     if (brackt) {
-      if (fabs(sty - stx) >= 0.66 * width1)
-        stp = stx + 0.5 * (sty - stx);
+      if (fabs(sty - stx) >= 0.66 * width1) stp = stx + 0.5 * (sty - stx);
       width1 = width;
       width = fabs(sty - stx);
     }
@@ -169,8 +161,7 @@ int MoreThuente::cstep(scalar_t &stx, scalar_t &fx, scalar_t &dx, scalar_t &sty,
     scalar_t theta = 3. * (fx - fp) / (stp - stx) + dx + dp;
     scalar_t s = std::max<scalar_t>(theta, std::max<scalar_t>(dx, dp));
     scalar_t gamma = s * sqrt((theta / s) * (theta / s) - (dx / s) * (dp / s));
-    if (stp < stx)
-      gamma = -gamma;
+    if (stp < stx) gamma = -gamma;
     scalar_t p = (gamma - dx) + theta;
     scalar_t q = ((gamma - dx) + gamma) + dp;
     scalar_t r = p / q;
@@ -187,8 +178,7 @@ int MoreThuente::cstep(scalar_t &stx, scalar_t &fx, scalar_t &dx, scalar_t &sty,
     scalar_t theta = 3 * (fx - fp) / (stp - stx) + dx + dp;
     scalar_t s = std::max<scalar_t>(theta, std::max<scalar_t>(dx, dp));
     scalar_t gamma = s * sqrt((theta / s) * (theta / s) - (dx / s) * (dp / s));
-    if (stp > stx)
-      gamma = -gamma;
+    if (stp > stx) gamma = -gamma;
     scalar_t p = (gamma - dp) + theta;
     scalar_t q = ((gamma - dp) + gamma) + dx;
     scalar_t r = p / q;
@@ -204,11 +194,10 @@ int MoreThuente::cstep(scalar_t &stx, scalar_t &fx, scalar_t &dx, scalar_t &sty,
     bound = 1;
     scalar_t theta = 3 * (fx - fp) / (stp - stx) + dx + dp;
     scalar_t s = std::max<scalar_t>(theta, std::max<scalar_t>(dx, dp));
-    scalar_t gamma = s * sqrt(std::max<scalar_t>(static_cast<scalar_t>(0.),
-                                                 (theta / s) * (theta / s) -
-                                                     (dx / s) * (dp / s)));
-    if (stp > stx)
-      gamma = -gamma;
+    scalar_t gamma = s * sqrt(std::max<scalar_t>(
+                             static_cast<scalar_t>(0.),
+                             (theta / s) * (theta / s) - (dx / s) * (dp / s)));
+    if (stp > stx) gamma = -gamma;
     scalar_t p = (gamma - dp) + theta;
     scalar_t q = (gamma + (dx - dp)) + gamma;
     scalar_t r = p / q;
@@ -241,8 +230,7 @@ int MoreThuente::cstep(scalar_t &stx, scalar_t &fx, scalar_t &dx, scalar_t &sty,
       scalar_t s = std::max<scalar_t>(theta, std::max<scalar_t>(dy, dp));
       scalar_t gamma =
           s * sqrt((theta / s) * (theta / s) - (dy / s) * (dp / s));
-      if (stp > sty)
-        gamma = -gamma;
+      if (stp > sty) gamma = -gamma;
 
       scalar_t p = (gamma - dp) + theta;
       scalar_t q = ((gamma - dp) + gamma) + dy;
@@ -304,4 +292,4 @@ double MoreThuente::line_search(Array<double> &x, Array<double> step) {
   opt_->set_rms(norm(g_) / sqrt(g_.size()));
   return alpha * opt_->compute_pot_norm(step);
 }
-} // namespace pele
+}  // namespace pele

--- a/source/mxd_end_only.cpp
+++ b/source/mxd_end_only.cpp
@@ -10,14 +10,15 @@
  */
 
 #include "pele/mxd_end_only.hpp"
-#include "pele/array.hpp"
-#include "pele/newton.hpp"
-#include "pele/optimizer.hpp"
 #include <Eigen/Dense>
 #include <cstddef>
 #include <iostream>
 #include <memory>
 #include <pele/cvode.hpp>
+
+#include "pele/array.hpp"
+#include "pele/newton.hpp"
+#include "pele/optimizer.hpp"
 
 using namespace std;
 namespace pele {
@@ -28,11 +29,13 @@ MixedDescentEndOnly::MixedDescentEndOnly(
     double threshold, bool iterative)
     : GradientOptimizer(potential, x0, tol),
       _cvode_optimizer(potential, x0, tol, rtol, atol, DENSE,
-                       false), // initialize the CVODE optimizer
+                       false),  // initialize the CVODE optimizer
       _newton_optimizer(potential, x0, tol, threshold,
-                        false), // initialize the Newton optimizer with the
-                                // rattler mask option passed as true
-      _tol(tol), _newton_step_tol(newton_step_tol), use_newton_step(false),
+                        false),  // initialize the Newton optimizer with the
+                                 // rattler mask option passed as true
+      _tol(tol),
+      _newton_step_tol(newton_step_tol),
+      use_newton_step(false),
 
       particle_disp(potential->get_ndim()) {}
 
@@ -98,4 +101,4 @@ bool MixedDescentEndOnly::stop_criterion_satisfied() {
   // std::cout << "should not be here" << std::endl;
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/mxopt.cpp
+++ b/source/mxopt.cpp
@@ -1,12 +1,5 @@
 
 #include "pele/mxopt.hpp"
-#include "pele/array.hpp"
-#include "pele/base_potential.hpp"
-#include "pele/eigen_interface.hpp"
-#include "pele/lbfgs.hpp"
-#include "pele/lsparameters.hpp"
-#include "pele/optimizer.hpp"
-#include "pele/preprocessor_directives.hpp"
 #include <algorithm>
 #include <complex>
 #include <cvode/cvode.h>
@@ -14,10 +7,17 @@
 #include <limits>
 #include <memory>
 #include <sundials/sundials_context.h>
-#include <sunlinsol/sunlinsol_dense.h> // access to dense SUNLinearSolver
-#include <sunlinsol/sunlinsol_spgmr.h> /* access to SPGMR SUNLinearSolver */
+#include <sunlinsol/sunlinsol_dense.h>  // access to dense SUNLinearSolver
+#include <sunlinsol/sunlinsol_spgmr.h>  /* access to SPGMR SUNLinearSolver */
 #include <sunnonlinsol/sunnonlinsol_newton.h>
 
+#include "pele/array.hpp"
+#include "pele/base_potential.hpp"
+#include "pele/eigen_interface.hpp"
+#include "pele/lbfgs.hpp"
+#include "pele/lsparameters.hpp"
+#include "pele/optimizer.hpp"
+#include "pele/preprocessor_directives.hpp"
 
 namespace pele {
 
@@ -25,13 +25,24 @@ MixedOptimizer::MixedOptimizer(std::shared_ptr<pele::BasePotential> potential,
                                const pele::Array<double> x0, double tol, int T,
                                double step, double conv_tol, double conv_factor,
                                double rtol, double atol, bool iterative)
-    : GradientOptimizer(potential, x0, tol), N_size(x_.size()), t0(0),
-      tN(100.0), rtol(rtol), atol(atol), xold(x_.size()), gold(x_.size()),
-      step(x_.size()), T_(T), usephase1(true), conv_tol_(conv_tol),
-      conv_factor_(conv_factor), n_phase_1_steps(0), n_phase_2_steps(0),
-      hessian(x_.size(), x_.size()), hessian_shifted(x_.size(), x_.size()),
+    : GradientOptimizer(potential, x0, tol),
+      N_size(x_.size()),
+      t0(0),
+      tN(100.0),
+      rtol(rtol),
+      atol(atol),
+      xold(x_.size()),
+      gold(x_.size()),
+      step(x_.size()),
+      T_(T),
+      usephase1(true),
+      conv_tol_(conv_tol),
+      conv_factor_(conv_factor),
+      n_phase_1_steps(0),
+      n_phase_2_steps(0),
+      hessian(x_.size(), x_.size()),
+      hessian_shifted(x_.size(), x_.size()),
       line_search_method(this, step) {
-
   // assume previous phase is phase 1
   prev_phase_is_phase1 = true;
 
@@ -116,7 +127,6 @@ void MixedOptimizer::one_iteration() {
 
     compute_phase_1_step(step);
   } else {
-
 #if OPTIMIZER_DEBUG_LEVEL >= 3
     std::cout << " computing phase 2 step"
               << "\n";
@@ -135,7 +145,8 @@ void MixedOptimizer::one_iteration() {
 
 #if OPTIMIZER_DEBUG_LEVEL >= 3
   std::cout << "mixed optimizer: " << iter_number_ << " E " << f_ << " rms "
-            << gradient_norm_ << " nfev " << nfev_ << " nhev " << udata.nhev << std::endl;
+            << gradient_norm_ << " nfev " << nfev_ << " nhev " << udata.nhev
+            << std::endl;
 #endif
   /**
    * Checks whether the stop criterion is satisfied: if stop criterion is
@@ -151,8 +162,9 @@ void MixedOptimizer::one_iteration() {
  */
 void MixedOptimizer::reset(pele::Array<double> &x0) {
   if (x0.size() != x_.size()) {
-    throw std::invalid_argument("The number of degrees of freedom (x0.size()) "
-                                "cannot change when calling reset()");
+    throw std::invalid_argument(
+        "The number of degrees of freedom (x0.size()) "
+        "cannot change when calling reset()");
   }
   iter_number_ = 0;
   nfev_ = 0;
@@ -170,7 +182,6 @@ with help convexity flag false ->
 out the result.
  */
 bool MixedOptimizer::convexity_check() {
-
   get_hess(hessian);
 
   hessian_shifted = hessian;
@@ -210,7 +221,7 @@ bool MixedOptimizer::convexity_check() {
 void MixedOptimizer::get_hess(Eigen::MatrixXd &hessian) {
   Array<double> hessian_pele = Array<double>(hessian.data(), hessian.size());
   potential_->get_hessian(
-      x_, hessian_pele); // preferably switch this to sparse Eigen
+      x_, hessian_pele);  // preferably switch this to sparse Eigen
   udata.nhev += 1;
 }
 
@@ -249,7 +260,6 @@ void MixedOptimizer::compute_phase_1_step(Array<double> step) {
  * Phase 2 The problem looks convex enough to switch to a newton method
  */
 void MixedOptimizer::compute_phase_2_step(Array<double> step) {
-
   if (hessian_calculated == false) {
     // we can afford to perform convexity checks at every steps
     // assuming the rate limiting cost is the hessian which is calculated
@@ -272,4 +282,4 @@ void MixedOptimizer::compute_phase_2_step(Array<double> step) {
   n_phase_2_steps += 1;
   prev_phase_is_phase1 = false;
 }
-} // namespace pele
+}  // namespace pele

--- a/source/newton.cpp
+++ b/source/newton.cpp
@@ -1,4 +1,5 @@
 #include "pele/newton.hpp"
+
 #include "Eigen/src/Eigenvalues/SelfAdjointEigenSolver.h"
 #include "pele/array.hpp"
 #include "pele/eigen_interface.hpp"
@@ -18,12 +19,19 @@ namespace pele {
 Newton::Newton(std::shared_ptr<BasePotential> potential,
                const pele::Array<double> &x0, double tol, double threshold,
                bool use_rattler_mask)
-    : GradientOptimizer(potential, x0, tol), _threshold(threshold),
-      _tolerance(tol), _hessian(x0.size(), x0.size()), _gradient(x0.size()),
-      _x(x0.size()), _rattlers_found(false),
-      _use_rattler_mask(use_rattler_mask), _not_rattlers(x0.size(), true),
-      _line_search(this, 1.0), _nhev(0), _x_old(x0.size()),
-      _gradient_old(x0.size()) // use step size of 1.0 for newton
+    : GradientOptimizer(potential, x0, tol),
+      _threshold(threshold),
+      _tolerance(tol),
+      _hessian(x0.size(), x0.size()),
+      _gradient(x0.size()),
+      _x(x0.size()),
+      _rattlers_found(false),
+      _use_rattler_mask(use_rattler_mask),
+      _not_rattlers(x0.size(), true),
+      _line_search(this, 1.0),
+      _nhev(0),
+      _x_old(x0.size()),
+      _gradient_old(x0.size())  // use step size of 1.0 for newton
 {
   // write pele array data into the Eigen array
   for (size_t i = 0; i < x0.size(); ++i) {
@@ -140,8 +148,9 @@ void Newton::one_iteration() {
   // cout << "starting norm" << starting_norm << endl;
   // cout << "step norm" << stepnorm << endl;
   if (stepnorm / starting_norm < 1e-10) {
-    throw std::runtime_error("rescaled step decreased by too much. Newton "
-                             "might be in the wrong direction");
+    throw std::runtime_error(
+        "rescaled step decreased by too much. Newton "
+        "might be in the wrong direction");
   }
   cout << "starting step size" << starting_norm << endl;
   cout << "step size rescaled" << stepnorm << endl;
@@ -165,4 +174,4 @@ void Newton::compute_func_gradient(Array<double> x, double &func,
   }
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/newton_with_extension.cpp
+++ b/source/newton_with_extension.cpp
@@ -1,8 +1,9 @@
 #include "pele/newton_with_extension.hpp"
+#include <memory>
+
 #include "pele/array.hpp"
 #include "pele/eigen_interface.hpp"
 #include "pele/optimizer.hpp"
-#include <memory>
 // Lapack for cholesky
 extern "C" {
 #include <lapacke.h>
@@ -20,16 +21,21 @@ NewtonWithExtendedPotential::NewtonWithExtendedPotential(
     double tol, std::shared_ptr<BasePotential> potential_extension,
     double translation_offset, double max_step)
     : GradientOptimizer(potential, x0, tol),
-      _translation_offset(translation_offset), _max_step(max_step),
-      _potential_extension(potential_extension), _hessian(x0.size(), x0.size()),
-      _gradient(x0.size()), _x(x0.size()), _line_search(this, 1.0),
-      _x_old(x0.size()), _gradient_old(x0.size()) {
+      _translation_offset(translation_offset),
+      _max_step(max_step),
+      _potential_extension(potential_extension),
+      _hessian(x0.size(), x0.size()),
+      _gradient(x0.size()),
+      _x(x0.size()),
+      _line_search(this, 1.0),
+      _x_old(x0.size()),
+      _gradient_old(x0.size()) {
   // Setup the extended potential
   _potential_extension = potential_extension;
   _extended_potential_wrapper =
       std::make_shared<ExtendedPotential>(potential, potential_extension);
   set_potential(
-      _potential_extension); // write pele array data into the Eigen array
+      _potential_extension);  // write pele array data into the Eigen array
 
   // Save coordinates as an Eigen vector
   for (size_t i = 0; i < x0.size(); ++i) {
@@ -38,7 +44,6 @@ NewtonWithExtendedPotential::NewtonWithExtendedPotential(
 }
 
 void NewtonWithExtendedPotential::reset(pele::Array<double> x) {
-
   // write pele array data into the Eigen array
   for (size_t i = 0; i < x.size(); ++i) {
     _x(i) = x[i];
@@ -85,8 +90,9 @@ void NewtonWithExtendedPotential::one_iteration() {
   double stepnorm = _line_search.line_search(x_pele, step_pele);
 
   if (stepnorm / starting_norm < 1e-10) {
-    throw std::runtime_error("rescaled step decreased by too much. Newton "
-                             "might be in the wrong direction");
+    throw std::runtime_error(
+        "rescaled step decreased by too much. Newton "
+        "might be in the wrong direction");
   }
   // Careful about assignment
   x_.assign(x_pele);
@@ -95,4 +101,4 @@ void NewtonWithExtendedPotential::one_iteration() {
   iter_number_ += 1;
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/nwpele.cpp
+++ b/source/nwpele.cpp
@@ -4,7 +4,6 @@ namespace pele {
 
 double NocedalWrightLineSearch::line_search(Array<double> &x,
                                             Array<double> step) {
-
   eig_eq_pele(xoldvec, xold_);
   eig_eq_pele(gradvec, gold_);
 
@@ -40,8 +39,7 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
                                      const Vector &xp,
                                      const LBFGSParam &param) {
   // Check the function pointer reference
-  if (step <= Scalar(0))
-    throw std::invalid_argument("'step' must be positive");
+  if (step <= Scalar(0)) throw std::invalid_argument("'step' must be positive");
   // change
   // To make this implementation more similar to the other line search
   // methods in LBFGSpp, the symbol names from the literature
@@ -63,8 +61,8 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
     throw std::logic_error(
         "the moving direction increases the objective function value");
 
-  const Scalar test_decr = param.ftol * dg_init, // Sufficient decrease
-      test_curv = -param.wolfe * dg_init;        // Curvature
+  const Scalar test_decr = param.ftol * dg_init,  // Sufficient decrease
+      test_curv = -param.wolfe * dg_init;         // Curvature
 
   // Ends of the line search range (step_lo > step_hi is allowed)
   Scalar step_hi, step_lo = 0, fx_hi, fx_lo = fx_init, dg_hi, dg_lo = dg_init;
@@ -77,11 +75,9 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
   //     "Numerical Optimization", "Algorithm 3.5 (Line Search Algorithm)".
   int iter = 0;
   for (;;) {
-
     x.noalias() = xp + step * drt;
     fx = func_grad_wrapper(x, grad);
-    if (iter++ >= param.max_linesearch)
-      return;
+    if (iter++ >= param.max_linesearch) return;
     const Scalar dg = grad.dot(drt);
     if (fx - fx_init > step * test_decr || (0 < step_lo && fx >= fx_lo)) {
       step_hi = step;
@@ -99,8 +95,7 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
     fx_lo = fx;
     dg_lo = dg;
 
-    if (dg >= 0)
-      break;
+    if (dg >= 0) break;
 
     step *= expansion;
   }
@@ -166,7 +161,7 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
     step = (step_hi + step_lo) / 2;
     x.noalias() = xp + step * drt;
     fx = func_grad_wrapper(x, grad);
-    if (iter++ >= param.max_linesearch) { // Scalar ival;
+    if (iter++ >= param.max_linesearch) {  // Scalar ival;
       std::cout << grad << "drt \n";
       std::cout << drt.norm() << "norm \n";
       std::cout << xp << " starting configuration for error \n";
@@ -189,8 +184,9 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
 
     if (fx - fx_init > step * test_decr || fx >= fx_lo) {
       if (step == step_hi)
-        throw std::runtime_error("the line search routine failed, possibly due "
-                                 "to insufficient numeric precision");
+        throw std::runtime_error(
+            "the line search routine failed, possibly due "
+            "to insufficient numeric precision");
 
       step_hi = step;
       fx_hi = fx;
@@ -207,8 +203,9 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
       }
 
       if (step == step_lo)
-        throw std::runtime_error("the line search routine failed, possibly due "
-                                 "to insufficient numeric precision");
+        throw std::runtime_error(
+            "the line search routine failed, possibly due "
+            "to insufficient numeric precision");
 
       step_lo = step;
       fx_lo = fx;
@@ -217,4 +214,4 @@ void NocedalWrightLineSearch::LSFunc(Scalar &fx, Vector &x, Vector &grad,
   }
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/pele/EvaluatorInversePower.hpp
+++ b/source/pele/EvaluatorInversePower.hpp
@@ -48,7 +48,7 @@ namespace md {
    LJ potential.
 */
 class EvaluatorPairForceShiftedLJ {
-public:
+ public:
   //! Define the parameter type used by this pair potential evaluator
   typedef EvaluatorPairLJ::param_type param_type;
 
@@ -69,7 +69,8 @@ public:
   */
   DEVICE EvaluatorPairForceShiftedLJ(Scalar _rsq, Scalar _rcutsq,
                                      const param_type &_params)
-      : rsq(_rsq), rcutsq(_rcutsq),
+      : rsq(_rsq),
+        rcutsq(_rcutsq),
         lj1(_params.epsilon_x_4 * _params.sigma_6 * _params.sigma_6),
         lj2(_params.epsilon_x_4 * _params.sigma_6) {}
 
@@ -112,8 +113,7 @@ public:
       Scalar rcut2inv = Scalar(1.0) / rcutsq;
       Scalar rcut6inv = rcut2inv * rcut2inv * rcut2inv;
 
-      if (energy_shift)
-        pair_eng -= rcut6inv * (lj1 * rcut6inv - lj2);
+      if (energy_shift) pair_eng -= rcut6inv * (lj1 * rcut6inv - lj2);
 
       // shift force and add linear term to potential
       Scalar rcut_r_inv = fast::rsqrt(rsq * rcutsq);
@@ -143,16 +143,16 @@ public:
   }
 #endif
 
-protected:
-  Scalar rsq;    //!< Stored rsq from the constructor
-  Scalar rcutsq; //!< Stored rcutsq from the constructor
-  Scalar lj1;    //!< lj1 parameter extracted from the params passed to the
-                 //!< constructor
-  Scalar lj2;    //!< lj2 parameter extracted from the params passed to the
-                 //!< constructor
+ protected:
+  Scalar rsq;     //!< Stored rsq from the constructor
+  Scalar rcutsq;  //!< Stored rcutsq from the constructor
+  Scalar lj1;     //!< lj1 parameter extracted from the params passed to the
+                  //!< constructor
+  Scalar lj2;     //!< lj2 parameter extracted from the params passed to the
+                  //!< constructor
 };
 
-} // end namespace md
-} // end namespace hoomd_pele
+}  // end namespace md
+}  // end namespace hoomd_pele
 
-#endif // __PAIR_EVALUATOR_FORCE_SHIFTED_LJ_H__
+#endif  // __PAIR_EVALUATOR_FORCE_SHIFTED_LJ_H__

--- a/source/pele/aatopology.hpp
+++ b/source/pele/aatopology.hpp
@@ -44,7 +44,7 @@ class CoordsAdaptor {
   pele::Array<double> _coords;
   static const size_t _ndim = 3;
 
-public:
+ public:
   CoordsAdaptor(size_t nrigid, size_t natoms, pele::Array<double> coords)
       : _nrigid(nrigid), _natoms(natoms), _coords(coords) {
     if (coords.size() != (6 * _nrigid + 3 * _natoms)) {
@@ -128,7 +128,7 @@ class RBTopology;
  * This is the base class from which all Transform Policies should be derived
  */
 class TransformPolicy {
-public:
+ public:
   //    void translate(self, X, d) {
   //        ''' translate the coordinates '''
   //    }
@@ -154,7 +154,7 @@ public:
  * Routines to apply transformations to a rigid body cluster
  */
 class TransformAACluster : public TransformPolicy {
-public:
+ public:
   pele::RBTopology *m_topology;
   TransformAACluster(pele::RBTopology *topology) : m_topology(topology) {}
   virtual ~TransformAACluster() {}
@@ -170,7 +170,7 @@ public:
 };
 
 class MeasureAngleAxisCluster {
-public:
+ public:
   pele::RBTopology *m_topology;
   MeasureAngleAxisCluster(pele::RBTopology *topology) : m_topology(topology) {}
 
@@ -192,13 +192,13 @@ class RigidFragment {
 
   std::shared_ptr<DistanceInterface> m_distance_function;
 
-  double m_M;          // total mass of the angle axis site
-  double m_W;          // sum of all weights
-  pele::VecN<3> m_cog; // center of geometry
+  double m_M;           // total mass of the angle axis site
+  double m_W;           // sum of all weights
+  pele::VecN<3> m_cog;  // center of geometry
   pele::MatrixNM<3, 3>
-      m_S; // weighted tensor of gyration S_ij = \sum m_i x_i x_j
+      m_S;  // weighted tensor of gyration S_ij = \sum m_i x_i x_j
   pele::MatrixNM<3, 3>
-      m_inversion; // matrix that applies the appropriate inversion
+      m_inversion;  // matrix that applies the appropriate inversion
   bool m_can_invert;
 
   // a list of rotations that leave the rigid body unchanged.
@@ -208,7 +208,7 @@ class RigidFragment {
   // coords[atom_indices[i]] is the first coordinate of the i'th atom
   pele::Array<size_t> m_atom_indices;
 
-public:
+ public:
   RigidFragment(pele::Array<double> atom_positions, Array<double> cog, double M,
                 double W, Array<double> S, Array<double> inversion,
                 bool can_invert,
@@ -216,8 +216,13 @@ public:
       : _atom_positions(atom_positions.copy()),
         _atom_positions_matrix(_atom_positions, _ndim),
         _natoms(_atom_positions.size() / _ndim),
-        m_distance_function(distance_function), m_M(M), m_W(W), m_cog(cog),
-        m_S(S), m_inversion(inversion), m_can_invert(can_invert) {
+        m_distance_function(distance_function),
+        m_M(M),
+        m_W(W),
+        m_cog(cog),
+        m_S(S),
+        m_inversion(inversion),
+        m_can_invert(can_invert) {
     if (_atom_positions.size() == 0) {
       throw std::invalid_argument("the atom positions must not have zero size");
     }
@@ -251,8 +256,8 @@ public:
   /**
    * access the vector of symmetry rotations
    */
-  inline std::vector<pele::MatrixNM<3, 3>> const &
-  get_symmetry_rotations() const {
+  inline std::vector<pele::MatrixNM<3, 3>> const &get_symmetry_rotations()
+      const {
     return m_symmetry_rotations;
   }
 
@@ -336,7 +341,7 @@ class RBTopology {
   std::vector<RigidFragment> _sites;
   size_t _natoms_total;
 
-public:
+ public:
   RBTopology() : _natoms_total(0) {}
 
   void add_site(RigidFragment const &site) {
@@ -511,10 +516,11 @@ class RBPotentialWrapper : public BasePotential {
   std::shared_ptr<BasePotential> potential_;
   std::shared_ptr<RBTopology> topology_;
 
-public:
+ public:
   RBPotentialWrapper(std::shared_ptr<BasePotential> potential,
                      std::shared_ptr<RBTopology> top)
-      : potential_(potential), topology_(top)
+      : potential_(potential),
+        topology_(top)
 
   {}
 
@@ -533,6 +539,6 @@ public:
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/array.hpp
+++ b/source/pele/array.hpp
@@ -17,7 +17,8 @@ namespace pele {
  * This manages the data of the Array class.  This can act as a simple wrapper
  * for a vector, or wrap an externally allocated block of memory.
  */
-template <typename dtype> class _ArrayMemory {
+template <typename dtype>
+class _ArrayMemory {
   std::vector<dtype> _vector;
   dtype
       *_data; /** _data will either point to the beginning of _vector, or to the
@@ -26,7 +27,7 @@ template <typename dtype> class _ArrayMemory {
   size_t _size; /** the size of the block of memory, whether in vector or
                    external. */
 
-public:
+ public:
   _ArrayMemory() : _vector(), _data(_vector.data()), _size(_vector.size()) {}
 
   _ArrayMemory(size_t size)
@@ -58,32 +59,36 @@ public:
  * This copy constructor and assignment operator act to wrap existing
  * memory rather than copy the memory.
  */
-template <typename dtype> class Array {
-protected:
+template <typename dtype>
+class Array {
+ protected:
   std::shared_ptr<_ArrayMemory<dtype>> _memory;
   dtype *_data; /**< _data will usually be a copy of memory->data().  If this
                    is a view of another array then _data will be
                    _memory->data() + ibegin */
   size_t _size; /**< The size of the array. */
-public:
+ public:
   /** create an array of size 0
    */
   Array()
-      : _memory(new _ArrayMemory<dtype>()), _data(_memory->data()),
+      : _memory(new _ArrayMemory<dtype>()),
+        _data(_memory->data()),
         _size(_memory->size()) {}
 
   /**
    * construct an array with a given size
    */
   Array(size_t size)
-      : _memory(new _ArrayMemory<dtype>(size)), _data(_memory->data()),
+      : _memory(new _ArrayMemory<dtype>(size)),
+        _data(_memory->data()),
         _size(_memory->size()) {}
 
   /**
    * construct an array with a given size, each element is a copy of val
    */
   Array(size_t size, dtype const &val)
-      : _memory(new _ArrayMemory<dtype>(size, val)), _data(_memory->data()),
+      : _memory(new _ArrayMemory<dtype>(size, val)),
+        _data(_memory->data()),
         _size(_memory->size())
 
   {}
@@ -92,7 +97,8 @@ public:
    * construct an array from an initializer list
    */
   Array(std::initializer_list<dtype> data)
-      : _memory(new _ArrayMemory<dtype>(data.size())), _data(_memory->data()),
+      : _memory(new _ArrayMemory<dtype>(data.size())),
+        _data(_memory->data()),
         _size(_memory->size()) {
     std::copy(data.begin(), data.end(), _data);
   }
@@ -101,7 +107,8 @@ public:
    * wrap some data that is passed.  Do not take ownership of the data.
    */
   Array(dtype *data, size_t size)
-      : _memory(new _ArrayMemory<dtype>(data, size)), _data(_memory->data()),
+      : _memory(new _ArrayMemory<dtype>(data, size)),
+        _data(_memory->data()),
         _size(_memory->size()) {}
 
   /**
@@ -109,14 +116,16 @@ public:
    */
   Array(dtype *data_begin, dtype *data_end)
       : _memory(new _ArrayMemory<dtype>(data_begin, data_end - data_begin)),
-        _data(_memory->data()), _size(_memory->size()) {}
+        _data(_memory->data()),
+        _size(_memory->size()) {}
 
   /**
    * wrap the data in a vector.  This memory should never be deleted.
    */
   Array(std::vector<dtype> &x)
       : _memory(new _ArrayMemory<dtype>(x.data(), x.size())),
-        _data(_memory->data()), _size(_memory->size()) {}
+        _data(_memory->data()),
+        _size(_memory->size()) {}
 
   /**
    * wrap another array is implemented by shared_ptr parent class
@@ -408,8 +417,9 @@ public:
    */
   dtype prod() const {
     if (empty()) {
-      throw std::runtime_error("array::prod(): array is empty, can't take "
-                               "product of array elements");
+      throw std::runtime_error(
+          "array::prod(): array is empty, can't take "
+          "product of array elements");
     }
     return std::accumulate(begin(), end(), dtype(1), std::multiplies<dtype>());
   }
@@ -441,8 +451,7 @@ public:
 template <class dtype>
 inline std::ostream &operator<<(std::ostream &out, const Array<dtype> &a) {
   for (size_t i = 0; i < a.size(); ++i) {
-    if (i > 0)
-      out << ", ";
+    if (i > 0) out << ", ";
     out << a[i];
   }
   out << std::endl;
@@ -468,6 +477,6 @@ Array<T> operator*(const U rhs, const Array<T> &lhs) {
   return (result *= rhs).copy();
 }
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef PYGMIN_ARRAY_H
+#endif  // #ifndef PYGMIN_ARRAY_H

--- a/source/pele/atlj.hpp
+++ b/source/pele/atlj.hpp
@@ -10,11 +10,12 @@
  *
  *
  */
+#include <memory>
+#include <vector>
+
 #include "array.hpp"
 #include "base_potential.hpp"
 #include "lj.hpp"
-#include <memory>
-#include <vector>
 extern "C" {
 #include "xsum.h"
 }
@@ -25,7 +26,7 @@ extern "C" {
 namespace pele {
 
 class ATLJ : public BasePotential {
-private:
+ private:
   double m_eps;
   double m_sig;
   double m_Z;
@@ -34,11 +35,11 @@ private:
   LJ ljpot;
   double get_axilrod_teller_energy(Array<double> const &x);
 
-public:
+ public:
   ATLJ(double sig, double eps, double Z);
   virtual ~ATLJ() {}
   double get_energy(Array<double> const &x);
 };
-} // namespace pele
+}  // namespace pele
 
-#endif // end header
+#endif  // end header

--- a/source/pele/atomlist_potential.hpp
+++ b/source/pele/atomlist_potential.hpp
@@ -1,15 +1,16 @@
 #ifndef _ATOMLIST_POTENTIAL_H_
 #define _ATOMLIST_POTENTIAL_H_
 
+#include <iostream>
+
 #include "array.hpp"
 #include "pairwise_potential_interface.hpp"
-#include <iostream>
 
 namespace pele {
 
 template <typename pairwise_interaction, typename distance_policy>
 class AtomListPotential : public PairwisePotentialInterface {
-protected:
+ protected:
   std::shared_ptr<pairwise_interaction> _interaction;
   std::shared_ptr<distance_policy> _dist;
   Array<size_t> _atoms1;
@@ -21,23 +22,32 @@ protected:
                     std::shared_ptr<distance_policy> dist,
                     Array<size_t> &atoms1, Array<size_t> &atoms2,
                     const Array<double> radii)
-      : PairwisePotentialInterface(radii), _interaction(interaction),
-        _dist(dist), _atoms1(atoms1.copy()), _atoms2(atoms2.copy()),
+      : PairwisePotentialInterface(radii),
+        _interaction(interaction),
+        _dist(dist),
+        _atoms1(atoms1.copy()),
+        _atoms2(atoms2.copy()),
         _one_list(false) {}
 
   AtomListPotential(std::shared_ptr<pairwise_interaction> interaction,
                     std::shared_ptr<distance_policy> dist,
                     Array<size_t> &atoms1, Array<size_t> &atoms2)
-      : _interaction(interaction), _dist(dist), _atoms1(atoms1.copy()),
-        _atoms2(atoms2.copy()), _one_list(false) {}
+      : _interaction(interaction),
+        _dist(dist),
+        _atoms1(atoms1.copy()),
+        _atoms2(atoms2.copy()),
+        _one_list(false) {}
 
   AtomListPotential(std::shared_ptr<pairwise_interaction> interaction,
                     std::shared_ptr<distance_policy> dist,
                     Array<size_t> &atoms1)
-      : _interaction(interaction), _dist(dist), _atoms1(atoms1.copy()),
-        _atoms2(_atoms1), _one_list(true) {}
+      : _interaction(interaction),
+        _dist(dist),
+        _atoms1(atoms1.copy()),
+        _atoms2(_atoms1),
+        _one_list(true) {}
 
-public:
+ public:
   virtual inline double get_energy(Array<double> const &x) {
     double e = 0.;
     size_t jstart = 0;
@@ -46,8 +56,7 @@ public:
     for (size_t i = 0; i < _atoms1.size(); ++i) {
       size_t atom1 = _atoms1[i];
       size_t i1 = _ndim * atom1;
-      if (_one_list)
-        jstart = i + 1;
+      if (_one_list) jstart = i + 1;
       for (size_t j = jstart; j < _atoms2.size(); ++j) {
         size_t atom2 = _atoms2[j];
         size_t i2 = _ndim * atom2;
@@ -92,11 +101,10 @@ public:
           r2 += dr[k] * dr[k];
         }
 
-        e += _interaction->energy_gradient(r2, &gij, get_non_additive_cutoff(atom1, atom2));
-        for (size_t k = 0; k < _ndim; ++k)
-          grad[i1 + k] -= gij * dr[k];
-        for (size_t k = 0; k < _ndim; ++k)
-          grad[i2 + k] += gij * dr[k];
+        e += _interaction->energy_gradient(
+            r2, &gij, get_non_additive_cutoff(atom1, atom2));
+        for (size_t k = 0; k < _ndim; ++k) grad[i1 + k] -= gij * dr[k];
+        for (size_t k = 0; k < _ndim; ++k) grad[i2 + k] += gij * dr[k];
       }
     }
 
@@ -136,12 +144,10 @@ public:
           r2 += dr[k] * dr[k];
         }
 
-        e += _interaction->energy_gradient_hessian(r2, &gij, &hij,
-                                                   get_non_additive_cutoff(atom1, atom2));
-        for (size_t k = 0; k < _ndim; ++k)
-          grad[i1 + k] -= gij * dr[k];
-        for (size_t k = 0; k < _ndim; ++k)
-          grad[i2 + k] += gij * dr[k];
+        e += _interaction->energy_gradient_hessian(
+            r2, &gij, &hij, get_non_additive_cutoff(atom1, atom2));
+        for (size_t k = 0; k < _ndim; ++k) grad[i1 + k] -= gij * dr[k];
+        for (size_t k = 0; k < _ndim; ++k) grad[i2 + k] += gij * dr[k];
 
         for (size_t k = 0; k < _ndim; ++k) {
           // diagonal block - diagonal terms
@@ -173,6 +179,6 @@ public:
     return e;
   }
 };
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/backtracking.hpp
+++ b/source/pele/backtracking.hpp
@@ -19,7 +19,7 @@ typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
 
 namespace pele {
 class BacktrackingLineSearch : LineSearch {
-public:
+ public:
   BacktrackingLineSearch(GradientOptimizer *opt,
                          Scalar inital_stpsize_ = Scalar(1.0),
                          Scalar max_step_ = Scalar(10.0), int m_ = 6,
@@ -32,9 +32,14 @@ public:
       : LineSearch(opt, max_step_),
         params(m_, epsilon_, epsilon_rel_, past_, delta_, max_linesearch_,
                min_step_, max_step_, ftol_, wolfe_, lstype_),
-        xsize(opt->get_x().size()), xdum(opt->get_x().copy()), gdum(xsize),
-        xvec(xsize), gradvec(xsize), initial_stpsize(inital_stpsize_),
-        step_direction(xsize), xoldvec(xsize),
+        xsize(opt->get_x().size()),
+        xdum(opt->get_x().copy()),
+        gdum(xsize),
+        xvec(xsize),
+        gradvec(xsize),
+        initial_stpsize(inital_stpsize_),
+        step_direction(xsize),
+        xoldvec(xsize),
         step_moving_away_from_min(false) {
     std::cout << inital_stpsize_ << "stpsize \n";
     std::cout << max_step_ << "max step \n";
@@ -50,7 +55,7 @@ public:
   inline double get_initial_stpsize() { return initial_stpsize; };
   bool get_step_moving_away_from_min() { return step_moving_away_from_min; };
 
-private:
+ private:
   LBFGSParam params;
   int xsize;
   double func_grad_wrapper(Vector &x, Vector &grad);
@@ -58,7 +63,7 @@ private:
   void LSFunc(Scalar &fx, Vector &x, Vector &grad, Scalar &step,
               const Vector &drt, const Vector &xp, const LBFGSParam &param);
 
-private:
+ private:
   Array<double> g_;
   Array<double> xold_;
   Array<double> gold_;
@@ -69,9 +74,9 @@ private:
   Scalar initial_stpsize;
   Vector step_direction;
   Vector xoldvec;
-  bool step_moving_away_from_min; // flag to inform the optimizer whether the
-                                  // step is moving to the minimum or not
+  bool step_moving_away_from_min;  // flag to inform the optimizer whether the
+                                   // step is moving to the minimum or not
 };
-} // namespace pele
+}  // namespace pele
 
-#endif // end #ifndef PELE_LINE_SEARCH_BACKTRACKING_H
+#endif  // end #ifndef PELE_LINE_SEARCH_BACKTRACKING_H

--- a/source/pele/base_interaction.hpp
+++ b/source/pele/base_interaction.hpp
@@ -20,6 +20,6 @@ struct BaseInteraction {
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // PYGMIN_BASE_INTERACTION_H
+#endif  // PYGMIN_BASE_INTERACTION_H

--- a/source/pele/base_potential.hpp
+++ b/source/pele/base_potential.hpp
@@ -1,13 +1,14 @@
 #ifndef PYGMIN_POTENTIAL_H
 #define PYGMIN_POTENTIAL_H
 
-#include "array.hpp"
 #include <assert.h>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+
+#include "array.hpp"
 
 extern "C" {
 #include "xsum.h"
@@ -19,7 +20,7 @@ namespace pele {
  * basic potential interface for native potentials
  */
 class BasePotential {
-public:
+ public:
   virtual ~BasePotential() {}
 
   /**
@@ -61,9 +62,8 @@ public:
     return energy;
   }
 
-  virtual double
-  get_energy_gradient(Array<double> const &x,
-                      std::vector<xsum_small_accumulator> &exact_grad) {
+  virtual double get_energy_gradient(
+      Array<double> const &x, std::vector<xsum_small_accumulator> &exact_grad) {
     throw std::runtime_error(
         "A numerical version for the exact gradient has not been written");
   }
@@ -96,12 +96,12 @@ public:
     return energy;
   }
 
-  virtual double
-  get_energy_gradient_hessian_rattlers(Array<double> const &x,
-                                       Array<double> &grad, Array<double> &hess,
-                                       Array<uint8_t> not_rattlers) {
-    throw std::runtime_error("BasePotential::get_energy_gradient_hessian with "
-                             "rattlers must be overloaded");
+  virtual double get_energy_gradient_hessian_rattlers(
+      Array<double> const &x, Array<double> &grad, Array<double> &hess,
+      Array<uint8_t> not_rattlers) {
+    throw std::runtime_error(
+        "BasePotential::get_energy_gradient_hessian with "
+        "rattlers must be overloaded");
   }
 
   virtual double get_energy_gradient(Array<double> const &x,
@@ -188,6 +188,6 @@ public:
    */
   virtual double compute_norm(pele::Array<double> const &x) { return norm(x); }
 };
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/bracketing.hpp
+++ b/source/pele/bracketing.hpp
@@ -18,7 +18,7 @@ typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
 
 namespace pele {
 class BracketingLineSearch : LineSearch {
-public:
+ public:
   BracketingLineSearch(GradientOptimizer *opt, Scalar max_step_ = Scalar(1.0),
                        int m_ = 6, Scalar epsilon_ = Scalar(1e-5),
                        Scalar epsilon_rel_ = Scalar(1e-5), int past_ = 0,
@@ -28,9 +28,14 @@ public:
       : LineSearch(opt, max_step_),
         params(m_, epsilon_, epsilon_rel_, past_, delta_, max_linesearch_,
                min_step_, max_step_, ftol_, wolfe_),
-        xsize(opt->get_x().size()), xdum(opt->get_x().copy()), gdum(xsize),
-        xvec(xsize), gradvec(xsize), stpsize(Scalar(1.0)),
-        step_direction(xsize), xoldvec(xsize){};
+        xsize(opt->get_x().size()),
+        xdum(opt->get_x().copy()),
+        gdum(xsize),
+        xvec(xsize),
+        gradvec(xsize),
+        stpsize(Scalar(1.0)),
+        step_direction(xsize),
+        xoldvec(xsize){};
   virtual ~BracketingLineSearch(){};
   inline void set_xold_gold_(Array<double> &xold, Array<double> &gold) {
     gold_ = gold;
@@ -40,7 +45,7 @@ public:
   inline void set_g_f_ptr(Array<double> &g) { g_ = g; };
   double line_search(Array<double> &x, Array<double> step);
 
-private:
+ private:
   LBFGSParam params;
   int xsize;
   double func_grad_wrapper(Vector &x, Vector &grad);
@@ -48,7 +53,7 @@ private:
   void LSFunc(Scalar &fx, Vector &x, Vector &grad, Scalar &step,
               const Vector &drt, const Vector &xp, const LBFGSParam &param);
 
-private:
+ private:
   Array<double> g_;
   Array<double> xold_;
   Array<double> gold_;
@@ -61,6 +66,6 @@ private:
   Vector xoldvec;
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // end #ifndef PELE_LINE_SEARCH_BRACKETING_H
+#endif  // end #ifndef PELE_LINE_SEARCH_BRACKETING_H

--- a/source/pele/cell_list_potential.hpp
+++ b/source/pele/cell_list_potential.hpp
@@ -58,13 +58,14 @@ inline size_t thread() {
 }
 
 // class containing r2, dij, dr, , xi_off, xj_off
-template <size_t ndim> class DistanceData {
-public:
-  double r2;                   // r2 = dr * dr
-  double dij;                  // cutoff distance between particles i and j
-  size_t xi_off;               // offset of particle i in the x array
-  size_t xj_off;               // offset of particle j in the x array
-  pele::VecN<ndim, double> dr; // vector from particle i to particle j
+template <size_t ndim>
+class DistanceData {
+ public:
+  double r2;                    // r2 = dr * dr
+  double dij;                   // cutoff distance between particles i and j
+  size_t xi_off;                // offset of particle i in the x array
+  size_t xj_off;                // offset of particle j in the x array
+  pele::VecN<ndim, double> dr;  // vector from particle i to particle j
   DistanceData() : r2(0), dij(0), xi_off(0), xj_off(0), dr() {}
   inline void reset() {
     r2 = 0;
@@ -75,8 +76,8 @@ public:
   }
 };
 template <size_t ndim>
-inline void
-init_distance_datas(std::vector<DistanceData<ndim>> &distance_datas) {
+inline void init_distance_datas(
+    std::vector<DistanceData<ndim>> &distance_datas) {
 #ifdef _OPENMP
   distance_datas = std::vector<DistanceData<ndim>>(omp_get_max_threads());
 #else
@@ -148,7 +149,7 @@ inline void accumulate_hessian(pele::Array<double> &hessian, const double hij,
  */
 template <typename pairwise_interaction, typename distance_policy>
 class BaseAccumulator {
-protected:
+ protected:
   const static size_t m_ndim = distance_policy::_ndim;
   std::shared_ptr<pairwise_interaction> m_interaction;
   std::shared_ptr<distance_policy> m_dist;
@@ -156,16 +157,19 @@ protected:
   const Array<double> m_radii;
   NonAdditiveCutoffCalculator m_cutoff;
   std::vector<DistanceData<distance_policy::_ndim>>
-      m_distance_datas; // distance data for every thread. Prevents being
-                        // overwritten by other threads
+      m_distance_datas;  // distance data for every thread. Prevents being
+                         // overwritten by other threads
 
-public:
+ public:
   BaseAccumulator(
       std::shared_ptr<pairwise_interaction> pairwise_interaction_ptr,
       std::shared_ptr<distance_policy> distance_policy_ptr,
       pele::Array<double> const &radii, NonAdditiveCutoffCalculator cutoff)
-      : m_interaction(pairwise_interaction_ptr), m_dist(distance_policy_ptr),
-        m_coords(nullptr), m_radii(radii), m_cutoff(cutoff),
+      : m_interaction(pairwise_interaction_ptr),
+        m_dist(distance_policy_ptr),
+        m_coords(nullptr),
+        m_radii(radii),
+        m_cutoff(cutoff),
         m_distance_datas(0) {
     init_distance_datas(m_distance_datas);
   }
@@ -177,11 +181,10 @@ public:
    * variables in the subdomain
    *
    */
-  inline void
-  calculate_distance_data(DistanceData<distance_policy::_ndim> &dist_data,
-                          const pele::Array<double> &coords,
-                          const size_t atom_i, const size_t atom_j) {
-
+  inline void calculate_distance_data(
+      DistanceData<distance_policy::_ndim> &dist_data,
+      const pele::Array<double> &coords, const size_t atom_i,
+      const size_t atom_j) {
     dist_data.xi_off = m_ndim * atom_i;
     dist_data.xj_off = m_ndim * atom_j;
     m_dist->get_rij(dist_data.dr.data(), m_coords->data() + dist_data.xi_off,
@@ -215,7 +218,7 @@ class EnergyAccumulator
     : public BaseAccumulator<pairwise_interaction, distance_policy> {
   std::vector<double> m_energies;
 
-public:
+ public:
   ~EnergyAccumulator() {}
 
   EnergyAccumulator(
@@ -244,7 +247,7 @@ public:
   }
   double get_energy() {
     return std::reduce(m_energies.begin(),
-                       m_energies.end()); // reduce sums up energies
+                       m_energies.end());  // reduce sums up energies
   }
 };
 
@@ -257,7 +260,7 @@ class EnergyGradientAccumulator
     : public BaseAccumulator<pairwise_interaction, distance_policy> {
   std::vector<double> m_energies;
 
-public:
+ public:
   pele::Array<double> *m_gradient;
   ~EnergyGradientAccumulator() {}
   EnergyGradientAccumulator(
@@ -303,7 +306,7 @@ class EnergyGradientHessianAccumulator
     : public BaseAccumulator<pairwise_interaction, distance_policy> {
   std::vector<double> m_energies;
 
-public:
+ public:
   pele::Array<double> *m_gradient;
   pele::Array<double> *m_hessian;
 
@@ -357,7 +360,7 @@ class EnergyHessianAccumulator
   std::vector<double> m_energies;
   pele::Array<double> *m_hessian;
 
-public:
+ public:
   ~EnergyHessianAccumulator() {}
 
   EnergyHessianAccumulator(
@@ -407,7 +410,7 @@ class EnergyAccumulatorExact {
   const pele::Array<double> m_radii;
   std::vector<xsum_large_accumulator> m_energies;
 
-public:
+ public:
   ~EnergyAccumulatorExact() {
     // for(auto & energy : m_energies) {
     //   delete energy;
@@ -483,7 +486,7 @@ class EnergyGradientAccumulatorExact {
   const pele::Array<double> m_radii;
   std::vector<xsum_large_accumulator> m_energies;
 
-public:
+ public:
   std::shared_ptr<std::vector<xsum_small_accumulator>> m_gradient;
   ~EnergyGradientAccumulatorExact() {
     // for(auto & energy : m_energies) {
@@ -506,9 +509,9 @@ public:
 #endif
   }
 
-  void
-  reset_data(const pele::Array<double> *coords,
-             std::shared_ptr<std::vector<xsum_small_accumulator>> &gradient) {
+  void reset_data(
+      const pele::Array<double> *coords,
+      std::shared_ptr<std::vector<xsum_small_accumulator>> &gradient) {
     m_coords = coords;
 #ifdef _OPENMP
 #pragma omp parallel
@@ -572,7 +575,7 @@ class EnergyGradientHessianAccumulatorExact {
   const pele::Array<double> m_radii;
   std::vector<double *> m_energies;
 
-public:
+ public:
   pele::Array<double> *m_gradient;
   pele::Array<double> *m_hessian;
 
@@ -694,7 +697,7 @@ class NeighborAccumulator {
   const double m_cutoff_sca;
   const pele::Array<short> m_include_atoms;
 
-public:
+ public:
   pele::Array<std::vector<size_t>> m_neighbor_indexes;
   pele::Array<std::vector<std::vector<double>>> m_neighbor_displacements;
 
@@ -704,9 +707,14 @@ public:
                       pele::Array<double> const &coords,
                       pele::Array<double> const &radii, const double cutoff_sca,
                       pele::Array<short> const &include_atoms)
-      : m_pot(pot), m_interaction(interaction), m_dist(dist), m_coords(coords),
-        m_radii(radii), m_cutoff_sca(cutoff_sca),
-        m_include_atoms(include_atoms), m_neighbor_indexes(radii.size()),
+      : m_pot(pot),
+        m_interaction(interaction),
+        m_dist(dist),
+        m_coords(coords),
+        m_radii(radii),
+        m_cutoff_sca(cutoff_sca),
+        m_include_atoms(include_atoms),
+        m_neighbor_indexes(radii.size()),
         m_neighbor_displacements(radii.size()) {}
 
   void insert_atom_pair(const size_t atom_i, const size_t atom_j,
@@ -747,14 +755,16 @@ class OverlapAccumulator {
   const pele::Array<double> m_coords;
   const pele::Array<double> m_radii;
 
-public:
+ public:
   std::vector<size_t> m_overlap_inds;
 
   OverlapAccumulator(std::shared_ptr<pairwise_interaction> &interaction,
                      std::shared_ptr<distance_policy> &dist,
                      pele::Array<double> const &coords,
                      pele::Array<double> const &radii)
-      : m_interaction(interaction), m_dist(dist), m_coords(coords),
+      : m_interaction(interaction),
+        m_dist(dist),
+        m_coords(coords),
         m_radii(radii) {}
 
   void insert_atom_pair(const size_t atom_i, const size_t atom_j,
@@ -788,7 +798,7 @@ public:
  */
 template <typename pairwise_interaction, typename distance_policy>
 class CellListPotential : public PairwisePotentialInterface {
-protected:
+ protected:
   const static size_t m_ndim = distance_policy::_ndim;
   pele::CellLists<distance_policy> m_cell_lists;
   std::shared_ptr<pairwise_interaction> m_interaction;
@@ -812,7 +822,7 @@ protected:
   EnergyGradientHessianAccumulatorExact<pairwise_interaction, distance_policy>
       *m_eghAccExact;
 
-public:
+ public:
   ~CellListPotential() {
     if (exact_sum) {
       delete m_eAccExact;
@@ -827,15 +837,19 @@ public:
 
   CellListPotential(std::shared_ptr<pairwise_interaction> interaction,
                     std::shared_ptr<distance_policy> dist,
-                    pele::Array<double> const &boxvec,
-                    double ncellx_scale, const pele::Array<double> radii,
+                    pele::Array<double> const &boxvec, double ncellx_scale,
+                    const pele::Array<double> radii,
                     NonAdditiveCutoffCalculator cutoff_calculator,
                     const double radii_sca = 0.0, const bool balance_omp = true,
                     const bool exact_sum = false)
       : PairwisePotentialInterface(radii, cutoff_calculator),
-        m_cell_lists(dist, boxvec, this->get_max_cutoff(), ncellx_scale, balance_omp),
-        m_interaction(interaction), m_dist(dist), m_radii_sca(radii_sca),
-        exact_gradient_initialized(false), exact_sum(exact_sum) {
+        m_cell_lists(dist, boxvec, this->get_max_cutoff(), ncellx_scale,
+                     balance_omp),
+        m_interaction(interaction),
+        m_dist(dist),
+        m_radii_sca(radii_sca),
+        exact_gradient_initialized(false),
+        exact_sum(exact_sum) {
     if (exact_sum) {
       std::cout
           << "WARNING: Exact sum is not being maintained and will be removed"
@@ -879,8 +893,11 @@ public:
                     const double non_additivity = 0.0)
       : PairwisePotentialInterface(radii, non_additivity),
         m_cell_lists(dist, boxvec, rcut, ncellx_scale, balance_omp),
-        m_interaction(interaction), m_dist(dist), m_radii_sca(radii_sca),
-        exact_gradient_initialized(false), exact_sum(exact_sum) {
+        m_interaction(interaction),
+        m_dist(dist),
+        m_radii_sca(radii_sca),
+        exact_gradient_initialized(false),
+        exact_sum(exact_sum) {
     if (exact_sum) {
       std::cout
           << "WARNING: Exact sum is not being maintained and will be removed"
@@ -925,8 +942,11 @@ public:
                     double ncellx_scale, const bool balance_omp = true,
                     const bool exact_sum = false)
       : m_cell_lists(dist, boxvec, rcut, ncellx_scale, balance_omp),
-        m_interaction(interaction), m_dist(dist), m_radii_sca(0.0),
-        exact_gradient_initialized(false), exact_sum(exact_sum) {
+        m_interaction(interaction),
+        m_dist(dist),
+        m_radii_sca(0.0),
+        exact_gradient_initialized(false),
+        exact_sum(exact_sum) {
     if (exact_sum) {
       m_eAccExact =
           new EnergyAccumulatorExact<pairwise_interaction, distance_policy>(
@@ -934,8 +954,10 @@ public:
       m_egAccExact = new EnergyGradientAccumulatorExact<pairwise_interaction,
                                                         distance_policy>(
           m_interaction, m_dist);
-      m_eghAccExact = new EnergyGradientHessianAccumulatorExact<
-          pairwise_interaction, distance_policy>(m_interaction, m_dist);
+      m_eghAccExact =
+          new EnergyGradientHessianAccumulatorExact<pairwise_interaction,
+                                                    distance_policy>(
+              m_interaction, m_dist);
       std::cout << "Warning: exact sum not implemented for get_hessian"
                 << std::endl;
       m_ehAcc =
@@ -959,7 +981,6 @@ public:
   virtual size_t get_ndim() { return m_ndim; }
 
   virtual double get_energy(Array<double> const &coords) {
-
     const size_t natoms = coords.size() / m_ndim;
     if (m_ndim * natoms != coords.size()) {
       throw std::runtime_error(
@@ -1094,7 +1115,6 @@ public:
   }
 
   double get_energy_hessian(Array<double> const &coords, Array<double> &hess) {
-
     const size_t natoms = coords.size() / m_ndim;
     if (m_ndim * natoms != coords.size()) {
       throw std::runtime_error(
@@ -1181,8 +1201,9 @@ public:
           "include_atoms.size() is not equal to the number of atoms");
     }
     if (m_radii.size() == 0) {
-      throw std::runtime_error("Can't calculate neighbors, because the "
-                               "used interaction doesn't use radii. ");
+      throw std::runtime_error(
+          "Can't calculate neighbors, because the "
+          "used interaction doesn't use radii. ");
     }
 
     if (!std::isfinite(coords[0]) ||
@@ -1209,8 +1230,9 @@ public:
           "coords.size() is not divisible by the number of dimensions");
     }
     if (m_radii.size() == 0) {
-      throw std::runtime_error("Can't calculate neighbors, because the "
-                               "used interaction doesn't use radii. ");
+      throw std::runtime_error(
+          "Can't calculate neighbors, because the "
+          "used interaction doesn't use radii. ");
     }
 
     if (!std::isfinite(coords[0]) ||
@@ -1260,9 +1282,8 @@ public:
     return energy;
   }
 
-  virtual inline double
-  get_interaction_energy_gradient_hessian(double r2, double *gij, double *hij,
-                                          size_t atom_i, size_t atom_j) const {
+  virtual inline double get_interaction_energy_gradient_hessian(
+      double r2, double *gij, double *hij, size_t atom_i, size_t atom_j) const {
     double energy = m_interaction->energy_gradient_hessian(
         r2, gij, hij, get_non_additive_cutoff(atom_i, atom_j));
     *gij *= sqrt(r2);
@@ -1285,12 +1306,12 @@ public:
     return sqrt(max_x);
   }
 
-protected:
+ protected:
   void update_iterator(Array<double> const &coords) {
     m_cell_lists.update(coords);
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif //#ifndef _PELE_CELL_LIST_POTENTIAL_H
+#endif  //#ifndef _PELE_CELL_LIST_POTENTIAL_H

--- a/source/pele/cell_lists.hpp
+++ b/source/pele/cell_lists.hpp
@@ -19,12 +19,12 @@
 #include "vecn.hpp"
 
 #ifndef NDEBUG
-#define ASSERT_EX(condition, statement)                                        \
-  do {                                                                         \
-    if (!(condition)) {                                                        \
-      statement;                                                               \
-      assert(condition);                                                       \
-    }                                                                          \
+#define ASSERT_EX(condition, statement) \
+  do {                                  \
+    if (!(condition)) {                 \
+      statement;                        \
+      assert(condition);                \
+    }                                   \
   } while (false)
 #else
 #define ASSERT_EX(condition, statement) ((void)0)
@@ -38,8 +38,9 @@ using cell_t = std::vector<size_t>;
 /**
  * container for the cell lists
  */
-template <size_t ndim> class CellListsContainer {
-protected:
+template <size_t ndim>
+class CellListsContainer {
+ protected:
   /** Construct m_cell_atoms for each subdomain
    */
   void setup_cells(const size_t nsubdoms,
@@ -66,7 +67,7 @@ protected:
     }
   }
 
-public:
+ public:
   /**
    * m_cell_atoms is a vector of vectors with vectors of atom indices.
    *
@@ -170,12 +171,13 @@ inline double get_ncellx_scale(pele::Array<double> radii,
   return ncellsx_scale;
 }
 
-} // namespace pele
+}  // namespace pele
 
 namespace pele {
 
-template <typename distance_policy> class LatticeNeighbors {
-protected:
+template <typename distance_policy>
+class LatticeNeighbors {
+ protected:
   /** Calculate number of cells of each subdomain in the split direction (y)
    */
   void calc_subdom_stats() {
@@ -218,30 +220,33 @@ protected:
 #endif
   }
 
-public:
+ public:
   static const size_t ndim = distance_policy::_ndim;
-  const std::shared_ptr<distance_policy> m_dist; //!< the distance function
+  const std::shared_ptr<distance_policy> m_dist;  //!< the distance function
 
   typedef VecN<ndim, size_t> cell_vec_t;
   pele::VecN<ndim> m_boxvec;
-  pele::VecN<ndim> m_inv_boxvec; //!< inverse of boxvec
+  pele::VecN<ndim> m_inv_boxvec;  //!< inverse of boxvec
   double m_rcut;
-  cell_vec_t m_ncells_vec;      //!< the number of cells in each dimension
-  pele::VecN<ndim> m_rcell_vec; //!< the cell length in each dimension
+  cell_vec_t m_ncells_vec;       //!< the number of cells in each dimension
+  pele::VecN<ndim> m_rcell_vec;  //!< the cell length in each dimension
   size_t m_ncells;
   size_t m_nsubdoms;
-  std::vector<size_t> m_subdom_limits; //!< boundary indices of each subdomain
-                                       //!< in the split direction (y)
-  std::vector<size_t> m_subdom_ncells; //!< number of cells of each subdomain
-  bool m_subdoms_balanced; //!< true if all subdomains have the same number of
-                           //!< cells
-  size_t m_subdom_avg_len; //!< Average subdomain length. Only used in balanced
-                           //!< case, therefore integer.
+  std::vector<size_t> m_subdom_limits;  //!< boundary indices of each subdomain
+                                        //!< in the split direction (y)
+  std::vector<size_t> m_subdom_ncells;  //!< number of cells of each subdomain
+  bool m_subdoms_balanced;  //!< true if all subdomains have the same number of
+                            //!< cells
+  size_t m_subdom_avg_len;  //!< Average subdomain length. Only used in balanced
+                            //!< case, therefore integer.
 
   LatticeNeighbors(std::shared_ptr<distance_policy> const &dist,
                    pele::Array<double> const &boxvec, const double rcut,
                    pele::Array<size_t> const &ncells_vec)
-      : m_dist(dist), m_boxvec(boxvec), m_rcut(rcut), m_ncells_vec(ncells_vec),
+      : m_dist(dist),
+        m_boxvec(boxvec),
+        m_rcut(rcut),
+        m_ncells_vec(ncells_vec),
         m_inv_boxvec(ndim) {
 #ifdef _OPENMP
     m_nsubdoms = omp_get_max_threads();
@@ -453,7 +458,7 @@ public:
     auto lower_left2 = cell_vec_to_position(v2);
     pele::VecN<ndim> ll1, ll2, dr;
     pele::VecN<ndim>
-        minimum_dist; // the minimum possible distance in each direction
+        minimum_dist;  // the minimum possible distance in each direction
     for (size_t i = 0; i < ndim; ++i) {
       double min_dist = std::numeric_limits<double>::max();
       double dri;
@@ -601,14 +606,15 @@ public:
         global_ind_to_local_ind(global_jcell, local_jcell, jsubdom);
         cell_neighbors[global_icell].push_back(&cells[jsubdom][local_jcell]);
         if (isubdom == jsubdom) {
-          if (local_jcell >= local_icell) { // avoid duplicates
+          if (local_jcell >= local_icell) {  // avoid duplicates
             std::array<cell_t *, 2> neighbors = {&cells[isubdom][local_icell],
                                                  &cells[jsubdom][local_jcell]};
             neighbor_pairs_inner.push_back(neighbors);
           }
         } else {
-          if (pos_direction_y(global_icell,
-                              global_jcell)) { // avoid duplicates, balance load
+          if (pos_direction_y(
+                  global_icell,
+                  global_jcell)) {  // avoid duplicates, balance load
             std::array<cell_t *, 2> neighbors = {&cells[isubdom][local_icell],
                                                  &cells[jsubdom][local_jcell]};
             neighbor_pairs_boundary.push_back(neighbors);
@@ -651,16 +657,16 @@ public:
  */
 template <class visitor_t, typename distance_policy = periodic_distance<3>>
 class CellListsLoop {
-protected:
+ protected:
   static const size_t m_ndim = distance_policy::_ndim;
   typedef VecN<m_ndim, size_t> cell_vec_t;
   visitor_t &m_visitor;
   CellListsContainer<m_ndim> const &m_container;
   LatticeNeighbors<distance_policy> m_lattice_tool;
 
-  virtual void
-  loop_cell_pairs(std::vector<std::array<cell_t *, 2>> const &neighbor_pairs,
-                  const size_t isubdom) {
+  virtual void loop_cell_pairs(
+      std::vector<std::array<cell_t *, 2>> const &neighbor_pairs,
+      const size_t isubdom) {
     for (auto const &ijpair : neighbor_pairs) {
       cell_t *icell = ijpair[0];
       cell_t *jcell = ijpair[1];
@@ -689,10 +695,11 @@ protected:
     }
   }
 
-public:
+ public:
   CellListsLoop(visitor_t &visitor, CellListsContainer<m_ndim> const &container,
                 pele::LatticeNeighbors<distance_policy> lattice_tool)
-      : m_visitor(visitor), m_container(container),
+      : m_visitor(visitor),
+        m_container(container),
         m_lattice_tool(lattice_tool) {}
 
   void loop_through_atom_pairs() {
@@ -737,13 +744,14 @@ public:
  * element. This adds room for errors so in this first implementation we do not
  * account for that scenario
  */
-template <typename distance_policy = periodic_distance<3>> class CellLists {
-public:
+template <typename distance_policy = periodic_distance<3>>
+class CellLists {
+ public:
   static const size_t m_ndim = distance_policy::_ndim;
 
-protected:
-  bool m_initialized; // flag for whether the cell lists have been initialized
-                      // with coordinates
+ protected:
+  bool m_initialized;  // flag for whether the cell lists have been initialized
+                       // with coordinates
   pele::LatticeNeighbors<distance_policy> m_lattice_tool;
   std::vector<SafePushQueue<std::array<size_t, 2>>> add_atom_queue;
 
@@ -754,7 +762,7 @@ protected:
    */
   CellListsContainer<m_ndim> m_container;
 
-public:
+ public:
   ~CellLists() {}
 
   /**
@@ -771,8 +779,8 @@ public:
    * return the class which loops over the atom pairs with a callback function
    */
   template <class callback_class>
-  inline CellListsLoop<callback_class, distance_policy>
-  get_atom_pair_looper(callback_class &callback) const {
+  inline CellListsLoop<callback_class, distance_policy> get_atom_pair_looper(
+      callback_class &callback) const {
     return CellListsLoop<callback_class, distance_policy>(callback, m_container,
                                                           m_lattice_tool);
   }
@@ -810,7 +818,7 @@ public:
                        std::vector<size_t> const &iatoms,
                        std::vector<double> const &old_coords);
 
-protected:
+ protected:
   void print_warnings(const size_t natoms);
   void build_cell_neighbors_list();
   void reset_container(pele::Array<double> const &coords);
@@ -819,7 +827,7 @@ protected:
                                  std::vector<size_t> const &iatoms,
                                  std::vector<double> const &old_coords);
 
-private:
+ private:
   static Array<size_t> get_ncells_vec(Array<double> const &boxv,
                                       const double rcut,
                                       const double ncellx_scale,
@@ -844,8 +852,9 @@ CellLists<distance_policy>::CellLists(
         "(due to the split of subdomains in y-dimension)");
   }
   if (boxv.size() != m_ndim) {
-    throw std::runtime_error("CellLists::CellLists: distance policy boxv and "
-                             "cell list boxv differ in size");
+    throw std::runtime_error(
+        "CellLists::CellLists: distance policy boxv and "
+        "cell list boxv differ in size");
   }
   if (*std::min_element(boxv.begin(), boxv.end()) < rcut) {
     throw std::runtime_error("CellLists::CellLists: illegal rcut");
@@ -863,8 +872,9 @@ CellLists<distance_policy>::CellLists(
 #ifdef _OPENMP
   if (std::floor(ncellx_scale) != ncellx_scale && ncellx_scale > 1 &&
       omp_get_max_threads() > 1) {
-    throw std::runtime_error("CellLists::CellLists: Non-integer values > 1 of "
-                             "ncellx_scale can break the parallelization!");
+    throw std::runtime_error(
+        "CellLists::CellLists: Non-integer values > 1 of "
+        "ncellx_scale can break the parallelization!");
   }
 #endif
   size_t ncell_min = *std::min_element(m_lattice_tool.m_ncells_vec.begin(),
@@ -896,9 +906,10 @@ Array<size_t> CellLists<distance_policy>::get_ncells_vec(
   }
 #ifdef _OPENMP
   if (omp_get_max_threads() > res[1]) {
-    throw std::runtime_error("More threads than cells in y-direction. "
-                             "Reduce the number of threads "
-                             "(environment variable OMP_NUM_THREADS)!");
+    throw std::runtime_error(
+        "More threads than cells in y-direction. "
+        "Reduce the number of threads "
+        "(environment variable OMP_NUM_THREADS)!");
   }
   if (balance_omp) {
     res[1] = (res[1] / omp_get_max_threads()) * omp_get_max_threads();
@@ -1066,6 +1077,6 @@ void CellLists<distance_policy>::update_container_specific(
   }
 }
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef _PELE_CELL_LISTS_H_
+#endif  // #ifndef _PELE_CELL_LISTS_H_

--- a/source/pele/combination.hpp
+++ b/source/pele/combination.hpp
@@ -14,23 +14,26 @@
 
 namespace pele {
 
-template <class iterator_type> class combination_generator {
+template <class iterator_type>
+class combination_generator {
   iterator_type first, last;
   std::vector<bool> use;
   size_t r;
   typedef typename std::iterator_traits<iterator_type>::value_type element_type;
 
-public:
+ public:
   combination_generator(iterator_type first_, iterator_type last_, size_t r_)
       : first(first_), last(last_), r(r_) {
     use.resize(std::distance(first, last), false);
     if (r > use.size())
-      throw std::domain_error("pele::combination_generator: can't select more "
-                              "elements than exist for combination");
+      throw std::domain_error(
+          "pele::combination_generator: can't select more "
+          "elements than exist for combination");
     std::fill(use.end() - r, use.end(), true);
   }
 
-  template <class output_iterator> bool operator()(output_iterator result) {
+  template <class output_iterator>
+  bool operator()(output_iterator result) {
     iterator_type c = first;
     for (size_t i = 0; i < use.size(); ++i, ++c) {
       if (use[i]) {
@@ -42,11 +45,11 @@ public:
 };
 
 template <class iterator_type>
-combination_generator<iterator_type>
-make_combination_generator(iterator_type first, iterator_type last, size_t r) {
+combination_generator<iterator_type> make_combination_generator(
+    iterator_type first, iterator_type last, size_t r) {
   return combination_generator<iterator_type>(first, last, r);
 }
 
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/combine_potentials.hpp
+++ b/source/pele/combine_potentials.hpp
@@ -1,9 +1,10 @@
 #ifndef _PELE_COMBINE_POTENTIALS_H_
 #define _PELE_COMBINE_POTENTIALS_H_
-#include "base_potential.hpp"
 #include <cstddef>
 #include <list>
 #include <memory>
+
+#include "base_potential.hpp"
 
 namespace pele {
 
@@ -14,10 +15,10 @@ namespace pele {
  * types atoms
  */
 class CombinedPotential : public BasePotential {
-protected:
+ protected:
   std::list<std::shared_ptr<BasePotential>> _potentials;
 
-public:
+ public:
   CombinedPotential() {}
 
   /**
@@ -95,14 +96,13 @@ public:
  * of the old potential and the new potential.
  */
 class ExtendedPotential : public CombinedPotential {
-
-private:
+ private:
   bool use_extended_potential_;
   size_t nhev_extension;
   size_t nfev_extension;
   size_t neev_extension;
 
-public:
+ public:
   /**
    * @brief Construct a new Extended Potential object
    *
@@ -184,8 +184,8 @@ public:
   size_t get_nfev_extension() { return nfev_extension; }
   size_t get_neev_extension() { return neev_extension; }
   size_t get_nhev_extension() { return nhev_extension; }
-}; // ExtendedPotential
+};  // ExtendedPotential
 
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/cvode.hpp
+++ b/source/pele/cvode.hpp
@@ -117,7 +117,8 @@ class CVODEBDFOptimizer : public ODEBasedOptimizer {
                     double rtol = 1e-5, double atol = 1e-5,
                     HessianType hessian_type = DENSE,
                     bool use_newton_stop_criterion = false,
-                    bool save_trajectory = false);
+                    bool save_trajectory = false,
+                    int iterations_before_save = 1);
 
   ~CVODEBDFOptimizer();
 

--- a/source/pele/distance.hpp
+++ b/source/pele/distance.hpp
@@ -56,7 +56,8 @@ namespace pele {
 /**
  * compute the cartesian distance
  */
-template <size_t IDX> struct meta_dist {
+template <size_t IDX>
+struct meta_dist {
   static void f(double *const r_ij, double const *const r1,
                 double const *const r2) {
     const static size_t k = IDX - 1;
@@ -65,14 +66,16 @@ template <size_t IDX> struct meta_dist {
   }
 };
 
-template <> struct meta_dist<1> {
+template <>
+struct meta_dist<1> {
   static void f(double *const r_ij, double const *const r1,
                 double const *const r2) {
     r_ij[0] = r1[0] - r2[0];
   }
 };
 
-template <size_t ndim> struct cartesian_distance {
+template <size_t ndim>
+struct cartesian_distance {
   static const size_t _ndim = ndim;
   inline void get_rij(double *const r_ij, double const *const r1,
                       double const *const r2) const {
@@ -85,15 +88,15 @@ template <size_t ndim> struct cartesian_distance {
       xnew[i] = x[i];
     }
   }
-  inline void put_atom_in_box(double *const x) const {
-  }
+  inline void put_atom_in_box(double *const x) const {}
 };
 
 /**
  * periodic boundary conditions in rectangular box
  */
 
-template <size_t IDX> struct meta_periodic_distance {
+template <size_t IDX>
+struct meta_periodic_distance {
   static void f(double *const r_ij, double const *const r1,
                 double const *const r2, const double *box, const double *ibox) {
     const static size_t k = IDX - 1;
@@ -103,7 +106,8 @@ template <size_t IDX> struct meta_periodic_distance {
   }
 };
 
-template <> struct meta_periodic_distance<1> {
+template <>
+struct meta_periodic_distance<1> {
   static void f(double *const r_ij, double const *const r1,
                 double const *const r2, const double *box, const double *ibox) {
     r_ij[0] = r1[0] - r2[0];
@@ -127,7 +131,8 @@ template <> struct meta_periodic_distance<1> {
  * round_fast(x[k] * ibox[k]) == -1 and finally
  * (x[k] -= -1 * box[k]) == 0.3 * box[k]
  */
-template <size_t IDX> struct meta_image {
+template <size_t IDX>
+struct meta_image {
   static void f(double *const xnew, const double *x, const double *ibox,
                 const double *box) {
     const static size_t k = IDX - 1;
@@ -154,7 +159,8 @@ template <size_t IDX> struct meta_image {
   }
 };
 
-template <> struct meta_image<1> {
+template <>
+struct meta_image<1> {
   static void f(double *const xnew, const double *x, const double *ibox,
                 const double *box) {
     xnew[0] = x[0] - round_fast(x[0] * ibox[0]) * box[0];
@@ -175,8 +181,9 @@ template <> struct meta_image<1> {
   }
 };
 
-template <size_t ndim> class periodic_distance {
-public:
+template <size_t ndim>
+class periodic_distance {
+ public:
   static const size_t _ndim = ndim;
   double m_box[ndim];
   double m_ibox[ndim];
@@ -224,7 +231,8 @@ public:
  * periodic boundary conditions in rectangular box, where the upper and lower
  * are moved in x-direction by dx
  */
-template <size_t IDX> struct meta_leesedwards_distance {
+template <size_t IDX>
+struct meta_leesedwards_distance {
   static void f(double *const r_ij, double const *const r1,
                 double const *const r2, const double *box, const double *ibox,
                 const double &dx) {
@@ -235,7 +243,8 @@ template <size_t IDX> struct meta_leesedwards_distance {
   }
 };
 
-template <> struct meta_leesedwards_distance<2> {
+template <>
+struct meta_leesedwards_distance<2> {
   static void f(double *const r_ij, double const *const r1,
                 double const *const r2, const double *box, const double *ibox,
                 const double &dx) {
@@ -257,7 +266,8 @@ template <> struct meta_leesedwards_distance<2> {
  * meta_leesedwards_image applies the nearest Lees-Edwards image convention to
  * the coordinates of one particle, just like meta_image.
  */
-template <size_t IDX> struct meta_leesedwards_image {
+template <size_t IDX>
+struct meta_leesedwards_image {
   static void f(double *const xnew, const double *x, const double *ibox,
                 const double *box, const double dx) {
     const static size_t k = IDX - 1;
@@ -285,7 +295,8 @@ template <size_t IDX> struct meta_leesedwards_image {
   }
 };
 
-template <> struct meta_leesedwards_image<2> {
+template <>
+struct meta_leesedwards_image<2> {
   static void f(double *const xnew, const double *x, const double *ibox,
                 const double *box, const double dx) {
     // Apply Lees-Edwards boundary conditions in y-direction
@@ -335,19 +346,22 @@ template <> struct meta_leesedwards_image<2> {
  * periodic boundary conditions in rectangular box, where the upper and lower
  * periodic images are moved in x-direction by dx
  */
-template <size_t ndim> class leesedwards_distance {
-private:
-  double m_box[ndim];  //!< Box size
-  double m_ibox[ndim]; //!< Inverse box size
-  double m_dx; //!< Distance the ghost cells are moved by (i.e. amount of shear)
+template <size_t ndim>
+class leesedwards_distance {
+ private:
+  double m_box[ndim];   //!< Box size
+  double m_ibox[ndim];  //!< Inverse box size
+  double
+      m_dx;  //!< Distance the ghost cells are moved by (i.e. amount of shear)
 
-public:
-  static const size_t _ndim = ndim; //!< Number of box dimensions
+ public:
+  static const size_t _ndim = ndim;  //!< Number of box dimensions
 
   leesedwards_distance(Array<double> const box, const double shear)
       : m_dx(fmod(shear, 1.0) * box[1]) {
-    static_assert(ndim >= 2, "box dimension must be at least 2 for "
-                             "lees-edwards boundary conditions");
+    static_assert(ndim >= 2,
+                  "box dimension must be at least 2 for "
+                  "lees-edwards boundary conditions");
     if (box.size() != ndim) {
       throw std::invalid_argument("box.size() must be equal to ndim");
     }
@@ -358,8 +372,9 @@ public:
   }
 
   leesedwards_distance() {
-    static_assert(ndim >= 2, "box dimension must be at least 2 for "
-                             "lees-edwards boundary conditions");
+    static_assert(ndim >= 2,
+                  "box dimension must be at least 2 for "
+                  "lees-edwards boundary conditions");
     throw std::runtime_error(
         "The empty constructor is not available for Lees-Edwards boundaries.");
   }
@@ -391,8 +406,8 @@ public:
  */
 
 class DistanceInterface {
-protected:
-public:
+ protected:
+ public:
   virtual void get_rij(double *const r_ij, double const *const r1,
                        double const *const r2) const = 0;
   virtual ~DistanceInterface() {}
@@ -400,10 +415,10 @@ public:
 
 template <size_t ndim>
 class CartesianDistanceWrapper : public DistanceInterface {
-protected:
+ protected:
   cartesian_distance<ndim> _dist;
 
-public:
+ public:
   static const size_t _ndim = ndim;
   inline void get_rij(double *const r_ij, double const *const r1,
                       double const *const r2) const {
@@ -413,10 +428,10 @@ public:
 
 template <size_t ndim>
 class PeriodicDistanceWrapper : public DistanceInterface {
-protected:
+ protected:
   periodic_distance<ndim> _dist;
 
-public:
+ public:
   static const size_t _ndim = ndim;
   PeriodicDistanceWrapper(Array<double> const box) : _dist(box){};
 
@@ -428,10 +443,10 @@ public:
 
 template <size_t ndim>
 class LeesEdwardsDistanceWrapper : public DistanceInterface {
-protected:
+ protected:
   leesedwards_distance<ndim> _dist;
 
-public:
+ public:
   static const size_t _ndim = ndim;
   LeesEdwardsDistanceWrapper(Array<double> const box, const double shear)
       : _dist(box, shear){};
@@ -442,5 +457,5 @@ public:
   }
 };
 
-} // namespace pele
-#endif // #ifndef _PELE_DISTANCE_H
+}  // namespace pele
+#endif  // #ifndef _PELE_DISTANCE_H

--- a/source/pele/eigen_interface.hpp
+++ b/source/pele/eigen_interface.hpp
@@ -6,8 +6,9 @@
  */
 // #define EIGEN_USE_MKL_ALL
 
-#include "array.hpp"
 #include <Eigen/Dense>
+
+#include "array.hpp"
 
 namespace pele {
 // implicitly assumes that the arrays of same size
@@ -48,5 +49,5 @@ inline Eigen::VectorXd eig_eq_pele_data(Array<double> &x) {
   Eigen::Map<Eigen::VectorXd> vec(data, x.size());
   return vec;
 }
-} // end namespace pele
-#endif // end #ifndef _PELE_TO_EIG_H__
+}  // end namespace pele
+#endif  // end #ifndef _PELE_TO_EIG_H__

--- a/source/pele/frenkel.hpp
+++ b/source/pele/frenkel.hpp
@@ -8,12 +8,13 @@
 #ifndef PYGMIN_FRENKEL_H
 #define PYGMIN_FRENKEL_H
 
+#include <memory>
+
 #include "atomlist_potential.hpp"
 #include "base_interaction.hpp"
 #include "cell_list_potential.hpp"
 #include "distance.hpp"
 #include "simple_pairwise_potential.hpp"
-#include <memory>
 
 namespace pele {
 
@@ -27,7 +28,9 @@ struct frenkel_interaction : BaseInteraction {
   double const _rcut2;
   double const _prefactor;
   frenkel_interaction(double sig, double eps, double rcut)
-      : _eps(eps), _sig2(sig * sig), _rcut2(rcut * rcut),
+      : _eps(eps),
+        _sig2(sig * sig),
+        _rcut2(rcut * rcut),
         _prefactor(2 * _eps * (_rcut2 / _sig2) *
                    pow(3 / (2 * ((_rcut2 / _sig2) - 1)), 3)) {}
 
@@ -44,8 +47,7 @@ struct frenkel_interaction : BaseInteraction {
 
   /* calculate energy and gradient from distance squared, gradient is in
    * |g|/|rij| */
-  double inline energy_gradient(double r2, double *gij,
-                                double dij) const {
+  double inline energy_gradient(double r2, double *gij, double dij) const {
     double ir2 = 1.0 / r2;
     double cutoff_factor = _rcut2 * ir2 - 1;
     double sigma_factor = _sig2 * ir2 - 1;
@@ -76,7 +78,7 @@ struct frenkel_interaction : BaseInteraction {
 };
 
 class Frenkel : public pele::SimplePairwisePotential<frenkel_interaction> {
-public:
+ public:
   Frenkel(double sig, double eps, double rcut)
       : SimplePairwisePotential<frenkel_interaction>(
             std::make_shared<frenkel_interaction>(sig, eps, rcut)) {}
@@ -84,7 +86,7 @@ public:
 
 class FrenkelPeriodic : public SimplePairwisePotential<frenkel_interaction,
                                                        periodic_distance<3>> {
-public:
+ public:
   FrenkelPeriodic(double sig, double eps, double rcut,
                   Array<double> const boxvec)
       : SimplePairwisePotential<frenkel_interaction, periodic_distance<3>>(
@@ -100,7 +102,7 @@ public:
 template <size_t ndim>
 class FrenkelPeriodicCellLists
     : public CellListPotential<frenkel_interaction, periodic_distance<ndim>> {
-public:
+ public:
   FrenkelPeriodicCellLists(double sig, double eps, double rcut,
                            Array<double> const boxvec, double ncellx_scale)
       : CellListPotential<frenkel_interaction, periodic_distance<ndim>>(
@@ -109,7 +111,7 @@ public:
             ncellx_scale) {}
 };
 
-} // namespace pele
+}  // namespace pele
 
 #endif
 

--- a/source/pele/frozen_atoms.hpp
+++ b/source/pele/frozen_atoms.hpp
@@ -19,12 +19,12 @@ namespace pele {
  * degrees of freedom.
  */
 class FrozenCoordsConverter {
-protected:
+ protected:
   std::vector<double> const _reference_coords;
   std::vector<size_t> _frozen_dof;
   std::vector<size_t> _mobile_dof;
 
-public:
+ public:
   FrozenCoordsConverter(Array<double> const reference_coords,
                         Array<size_t> const frozen_dof)
       : _reference_coords(reference_coords.begin(), reference_coords.end()) {
@@ -139,10 +139,10 @@ public:
 };
 
 class FrozenPotentialWrapper : public BasePotential {
-protected:
+ protected:
   std::shared_ptr<BasePotential> _underlying_potential;
 
-public:
+ public:
   FrozenCoordsConverter coords_converter;
 
   FrozenPotentialWrapper(std::shared_ptr<BasePotential> potential,
@@ -225,6 +225,6 @@ public:
     return energy;
   }
 };
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/gaussianpot.hpp
+++ b/source/pele/gaussianpot.hpp
@@ -8,16 +8,18 @@
 namespace pele {
 
 class GaussianPot : public BasePotential {
-private:
+ private:
   const Array<double> m_mean;
   const Array<double> m_cov_diag;
   const double m_gauss_prefactor;
   const size_t m_bdim;
   std::vector<double> m_diag_icov;
 
-public:
+ public:
   GaussianPot(Array<double> mean, Array<double> cov_diag)
-      : m_mean(mean.copy()), m_cov_diag(cov_diag.copy()), m_gauss_prefactor(-1),
+      : m_mean(mean.copy()),
+        m_cov_diag(cov_diag.copy()),
+        m_gauss_prefactor(-1),
         m_bdim(mean.size()) {
     assert(m_mean.size() == m_bdim);
     assert(m_cov_diag.size() == m_bdim);
@@ -86,6 +88,6 @@ public:
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef _PELE_GAUSSIANPOT_H
+#endif  // #ifndef _PELE_GAUSSIANPOT_H

--- a/source/pele/generic_mixed_descent.hpp
+++ b/source/pele/generic_mixed_descent.hpp
@@ -15,7 +15,6 @@
 #ifndef PELE_MIXED_DESCENT_WITH_FIRE_HPP
 #define PELE_MIXED_DESCENT_WITH_FIRE_HPP
 
-#include "pele/combine_potentials.hpp"
 #include <Eigen/Dense>
 #include <cstddef>
 #include <iostream>
@@ -24,6 +23,8 @@
 #include <pele/base_potential.hpp>
 #include <pele/optimizer.hpp>
 
+#include "pele/combine_potentials.hpp"
+
 namespace pele {
 
 /**
@@ -31,20 +32,26 @@ namespace pele {
  * @details Base class for combining two optimizers.
  */
 class GenericMixedDescent : public GradientOptimizer {
-public:
+ public:
   GenericMixedDescent(std::shared_ptr<BasePotential> pot, Array<double> x,
                       double tol,
                       std::shared_ptr<GradientOptimizer> opt_non_convex,
                       std::shared_ptr<GradientOptimizer> opt_convex,
                       double translation_offset, int steps_before_convex_check,
                       std::shared_ptr<BasePotential> pot_extension = nullptr)
-      : GradientOptimizer(pot, x, tol), opt_non_convex_(opt_non_convex),
-        opt_convex_(opt_convex), hessian_(x.size(), x.size()),
-        hessian_copy_for_cholesky_(x.size(), x.size()), hessian_evaluations_(0),
+      : GradientOptimizer(pot, x, tol),
+        opt_non_convex_(opt_non_convex),
+        opt_convex_(opt_convex),
+        hessian_(x.size(), x.size()),
+        hessian_copy_for_cholesky_(x.size(), x.size()),
+        hessian_evaluations_(0),
         translation_offset_(translation_offset),
-        steps_before_convex_check_(steps_before_convex_check), in_convex_region_(false),
-        use_non_convex_method_(true), last_non_convex_x_(x.size()),
-        hessian_calculated_(false), n_phase_1_steps(0) {
+        steps_before_convex_check_(steps_before_convex_check),
+        in_convex_region_(false),
+        use_non_convex_method_(true),
+        last_non_convex_x_(x.size()),
+        hessian_calculated_(false),
+        n_phase_1_steps(0) {
     // Ensure that both optimizers have the same potential
     // There is redundancy because we add the potential to each optimizer
     // but this overrides the potential in the optimizer.
@@ -115,7 +122,7 @@ public:
     }
   }
 
-private:
+ private:
   std::shared_ptr<pele::GradientOptimizer> opt_non_convex_;
   std::shared_ptr<pele::GradientOptimizer> opt_convex_;
   /**
@@ -177,6 +184,6 @@ private:
   std::shared_ptr<ExtendedPotential> extended_potential_;
   bool pot_extension_provided_;
 };
-} // namespace pele
+}  // namespace pele
 
-#endif // !1
+#endif  // !1

--- a/source/pele/gradient_descent.hpp
+++ b/source/pele/gradient_descent.hpp
@@ -1,12 +1,13 @@
 #ifndef _PELE_GD_H__
 #define _PELE_GD_H__
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "optimizer.hpp"
 #include <memory>
 #include <pele/vecn.hpp>
 #include <vector>
+
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "optimizer.hpp"
 
 // line search methods
 #include "backtracking.hpp"
@@ -22,27 +23,31 @@ namespace pele {
  * An implementation of the standard gradient descent optimization algorithm in
  * c++. The learning rate (step size) is set via initial_step. defaults to
  * backtracking line search
- * This optimizer can also be viewed as a Forward Euler Integrator with the backtracking
- * line search as a time step controller. Hence this derives from ODEBasedOptimizer
- * which allows for storing the trajectory as a function of the time in the ODE.
+ * This optimizer can also be viewed as a Forward Euler Integrator with the
+ * backtracking line search as a time step controller. Hence this derives from
+ * ODEBasedOptimizer which allows for storing the trajectory as a function of
+ * the time in the ODE.
  */
 class GradientDescent : public ODEBasedOptimizer {
-private:
-  Array<double> xold; //!< Coordinates before taking a step
-  Array<double> step; //!< Step direction
+ private:
+  Array<double> xold;  //!< Coordinates before taking a step
+  Array<double> step;  //!< Step direction
   double
-      inv_sqrt_size; //!< The inverse square root the the number of components
-  BacktrackingLineSearch line_search_method; // Line search method
-  double step_size_;   //!< Step size
-public:
+      inv_sqrt_size;  //!< The inverse square root the the number of components
+  BacktrackingLineSearch line_search_method;  // Line search method
+  double step_size_;                          //!< Step size
+ public:
   /**
    * Constructor
    */
   GradientDescent(std::shared_ptr<pele::BasePotential> potential,
                   const pele::Array<double> x0, double tol = 1e-4,
                   double step_size = 1e-4, bool save_trajectory = true)
-      : ODEBasedOptimizer(potential, x0, tol, save_trajectory), xold(x_.size()), step(x_.size()),
-        line_search_method(this), step_size_(step_size) {
+      : ODEBasedOptimizer(potential, x0, tol, save_trajectory),
+        xold(x_.size()),
+        step(x_.size()),
+        line_search_method(this),
+        step_size_(step_size) {
     // set precision of printing
     std::cout << std::setprecision(std::numeric_limits<double>::max_digits10);
     inv_sqrt_size = 1 / sqrt(x_.size());
@@ -66,7 +71,7 @@ public:
     //  really need to refactor and clean this up
     Array<double> gold = g_.copy();
     // Gradient defines step direction
-    step = -g_.copy()*step_size_;
+    step = -g_.copy() * step_size_;
 
     // reduce the stepsize if necessary
     line_search_method.set_xold_gold_(xold, gold);
@@ -77,12 +82,12 @@ public:
 
     // Forward Euler time
     // dx = -dt * g => dt = |dx| / |g|
-    time_ += stepnorm/norm(gold);
+    time_ += stepnorm / norm(gold);
     // print some status information
     if ((iprint_ > 0) && (iter_number_ % iprint_ == 0)) {
       std::cout << "steepest descent: " << iter_number_ << " E " << f_
-                << " rms " << gradient_norm_ << " nfev " << nfev_ << " step norm "
-                << stepnorm << std::endl;
+                << " rms " << gradient_norm_ << " nfev " << nfev_
+                << " step norm " << stepnorm << std::endl;
     }
     iter_number_ += 1;
   }
@@ -102,6 +107,6 @@ public:
     initialize_func_gradient();
   }
 };
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/gradient_descent.hpp
+++ b/source/pele/gradient_descent.hpp
@@ -42,8 +42,10 @@ class GradientDescent : public ODEBasedOptimizer {
    */
   GradientDescent(std::shared_ptr<pele::BasePotential> potential,
                   const pele::Array<double> x0, double tol = 1e-4,
-                  double step_size = 1e-4, bool save_trajectory = true)
-      : ODEBasedOptimizer(potential, x0, tol, save_trajectory),
+                  double step_size = 1e-4, bool save_trajectory = true,
+                  int iterations_before_save = 1)
+      : ODEBasedOptimizer(potential, x0, tol, save_trajectory,
+                          iterations_before_save),
         xold(x_.size()),
         step(x_.size()),
         line_search_method(this),

--- a/source/pele/graph.hpp
+++ b/source/pele/graph.hpp
@@ -43,9 +43,9 @@ static color_type color_black = 4;
  * basic class for an edge (arc) in the graph
  */
 class Edge {
-public:
-  node_ptr head_; // node the edge points to
-  node_ptr tail_; // node the edge comes from
+ public:
+  node_ptr head_;  // node the edge points to
+  node_ptr tail_;  // node the edge comes from
   double P;
 
   Edge(node_ptr tail, node_ptr head) : head_(head), tail_(tail) {}
@@ -58,17 +58,17 @@ public:
  * basic class for a node in the graph
  */
 class Node {
-public:
+ public:
   typedef std::set<edge_ptr> edge_list;
   typedef typename edge_list::iterator edge_iterator;
   typedef std::map<node_ptr, edge_ptr> successor_map_t;
 
-private:
+ private:
   node_id id_;
-  edge_list out_edge_list_; // list of outgoing edges
-  edge_list in_edge_list_;  // list of outgoing edges
+  edge_list out_edge_list_;  // list of outgoing edges
+  edge_list in_edge_list_;   // list of outgoing edges
 
-public:
+ public:
   successor_map_t successor_map_;
   double tau;
 
@@ -124,7 +124,7 @@ inline std::set<node_ptr> Node::in_out_neighbors() {
 }
 
 class Graph {
-public:
+ public:
   typedef std::map<node_id, node_ptr> node_map_t;
   node_map_t node_map_;
   typedef std::set<edge_ptr> edge_list_t;
@@ -292,6 +292,6 @@ inline std::ostream &operator<<(std::ostream &out, std::shared_ptr<Graph> g) {
   return out;
 }
 
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/harmonic.hpp
+++ b/source/pele/harmonic.hpp
@@ -13,7 +13,7 @@
 namespace pele {
 
 class BaseHarmonic : public BasePotential {
-protected:
+ protected:
   virtual void _get_distance(const pele::Array<double> &x) = 0;
   pele::Array<double> _origin;
   pele::Array<double> _distance;
@@ -22,10 +22,13 @@ protected:
   const size_t _nparticles;
   BaseHarmonic(const pele::Array<double> origin, const double k,
                const size_t ndim)
-      : _origin(origin.copy()), _distance(origin.size()), _k(k), _ndim(ndim),
+      : _origin(origin.copy()),
+        _distance(origin.size()),
+        _k(k),
+        _ndim(ndim),
         _nparticles(origin.size() / _ndim) {}
 
-public:
+ public:
   virtual ~BaseHarmonic() {}
   virtual double inline get_energy(pele::Array<double> const &x);
   virtual double inline get_energy_gradient(pele::Array<double> const &x,
@@ -59,7 +62,7 @@ double inline BaseHarmonic::get_energy_gradient(pele::Array<double> const &x,
  * Simple Harmonic with cartesian distance
  */
 class Harmonic : public BaseHarmonic {
-public:
+ public:
   Harmonic(pele::Array<double> origin, double k, size_t ndim)
       : BaseHarmonic(origin, k, ndim) {}
   virtual void inline _get_distance(const pele::Array<double> &x) {
@@ -75,7 +78,7 @@ public:
  * Harmonic with cartesian distance and fixed centre of mass
  */
 class HarmonicCOM : public BaseHarmonic {
-public:
+ public:
   HarmonicCOM(pele::Array<double> origin, double k, size_t ndim)
       : BaseHarmonic(origin, k, ndim) {}
   virtual void inline _get_distance(const pele::Array<double> &x) {
@@ -136,7 +139,7 @@ struct harmonic_interaction : BaseInteraction {
  */
 class HarmonicAtomList
     : public AtomListPotential<harmonic_interaction, cartesian_distance<3>> {
-public:
+ public:
   HarmonicAtomList(double k, Array<size_t> atoms1, Array<size_t> atoms2)
       : AtomListPotential<harmonic_interaction, cartesian_distance<3>>(
             std::make_shared<harmonic_interaction>(k),
@@ -153,12 +156,12 @@ public:
  */
 class HarmonicNeighborList
     : public SimplePairwiseNeighborList<harmonic_interaction> {
-public:
+ public:
   HarmonicNeighborList(double k, Array<size_t> ilist)
       : SimplePairwiseNeighborList<harmonic_interaction>(
             std::make_shared<harmonic_interaction>(k), ilist) {}
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef _PELE_HARMONIC_H
+#endif  // #ifndef _PELE_HARMONIC_H

--- a/source/pele/hessian_translations.hpp
+++ b/source/pele/hessian_translations.hpp
@@ -21,7 +21,6 @@ namespace pele {
 
 void generate_2d_symmetries(size_t n_particles, Eigen::MatrixXd &projector_x,
                             Eigen::MatrixXd &projector_y) {
-
   projector_x.setZero();
   projector_y.setZero();
 
@@ -49,7 +48,6 @@ void generate_2d_symmetries(size_t n_particles, Eigen::MatrixXd &projector_x,
 void generate_3d_symmetries(size_t n_particles, Eigen::MatrixXd &projector_x,
                             Eigen::MatrixXd &projector_y,
                             Eigen::MatrixXd &projector_z) {
-
   projector_x.setZero();
   projector_y.setZero();
   projector_z.setZero();
@@ -112,7 +110,6 @@ std::vector<Eigen::MatrixXd> get_symmetries(size_t n_particles, size_t n_d) {
  * @param  offset the offset to be added
  */
 void add_translation_offset_2d(Eigen::MatrixXd &hessian, double offset) {
-
   // factor so that the added translation operators are unitary
   double factor = 2.0 / hessian.rows();
   offset = offset * factor;
@@ -128,5 +125,5 @@ void add_translation_offset_2d(Eigen::MatrixXd &hessian, double offset) {
   hessian.diagonal().array() += offset;
 }
 
-} // namespace pele
-#endif // TRANSLATION_SYMMETRY_MATRICES_HPP
+}  // namespace pele
+#endif  // TRANSLATION_SYMMETRY_MATRICES_HPP

--- a/source/pele/hs_wca.hpp
+++ b/source/pele/hs_wca.hpp
@@ -34,7 +34,8 @@ namespace pele {
  * linear is somewhat confusing because the gradient is originally
  * computed as grad / (-r).
  */
-template <size_t exp = 6> class sf_HS_WCA_interaction : BaseInteraction {
+template <size_t exp = 6>
+class sf_HS_WCA_interaction : BaseInteraction {
   const double m_eps;
   const double m_alpha1_2;
   const double m_delta;
@@ -44,15 +45,14 @@ template <size_t exp = 6> class sf_HS_WCA_interaction : BaseInteraction {
   constexpr static double m_hessian_prfac = 2 * (exp + 1) * m_grad_prfac;
   constexpr static double m_hessian_prfac2 = 2 * (2 * exp + 1) * m_grad_prfac2;
 
-public:
+ public:
   sf_HS_WCA_interaction(const double eps, const double alpha,
                         const double delta = 1e-10);
   double energy(const double r2, const double dij) const;
   double energy_gradient(const double r2, double *const gij,
                          const double dij) const;
   double energy_gradient_hessian(const double r2, double *const gij,
-                                 double *const hij,
-                                 const double dij) const;
+                                 double *const hij, const double dij) const;
   void evaluate_pair_potential(const double rmin, const double rmax,
                                const size_t nr_points, const double dij,
                                std::vector<double> &x,
@@ -63,7 +63,9 @@ template <size_t exp>
 sf_HS_WCA_interaction<exp>::sf_HS_WCA_interaction(const double eps,
                                                   const double alpha,
                                                   const double delta)
-    : m_eps(eps), m_alpha1_2(pos_int_pow<2>(alpha + 1)), m_delta(delta),
+    : m_eps(eps),
+      m_alpha1_2(pos_int_pow<2>(alpha + 1)),
+      m_delta(delta),
       m_prfac(0.5 * pos_int_pow<exp>((2 + alpha) * alpha)) {
   if (eps < 0) {
     throw std::runtime_error("HS_WCA: illegal input: eps");
@@ -109,9 +111,9 @@ double sf_HS_WCA_interaction<exp>::energy(const double r2,
 }
 
 template <size_t exp>
-double
-sf_HS_WCA_interaction<exp>::energy_gradient(const double r2, double *const gij,
-                                            const double dij) const {
+double sf_HS_WCA_interaction<exp>::energy_gradient(const double r2,
+                                                   double *const gij,
+                                                   const double dij) const {
   const double r_H2 = pos_int_pow<2>(dij);
   const double r_S2 = m_alpha1_2 * r_H2;
   if (r2 > r_S2) {
@@ -195,8 +197,7 @@ double sf_HS_WCA_interaction<exp>::energy_gradient_hessian(
 template <size_t exp>
 void sf_HS_WCA_interaction<exp>::evaluate_pair_potential(
     const double rmin, const double rmax, const size_t nr_points,
-    const double dij, std::vector<double> &x,
-    std::vector<double> &y) const {
+    const double dij, std::vector<double> &x, std::vector<double> &y) const {
   x = std::vector<double>(nr_points, 0);
   y = std::vector<double>(nr_points, 0);
   const double rdelta = (rmax - rmin) / (nr_points - 1);
@@ -219,7 +220,9 @@ struct HS_WCA_interaction : BaseInteraction {
   const double _prfac;
 
   HS_WCA_interaction(const double eps, const double sca)
-      : _eps(eps), _sca(sca), _infty(std::pow(10.0, 50)),
+      : _eps(eps),
+        _sca(sca),
+        _infty(std::pow(10.0, 50)),
         _prfac(0.5 * pos_int_pow<6>((2 + _sca) * _sca)) {}
 
   /* calculate energy from distance squared, r0 is the hard core distance, r is
@@ -230,12 +233,12 @@ struct HS_WCA_interaction : BaseInteraction {
       return _infty;
     }
     const double coff =
-        dij *
-        (1.0 + _sca); // distance at which the soft cores are at contact
+        dij * (1.0 + _sca);  // distance at which the soft cores are at contact
     if (r2 > coff * coff) {
       return 0;
     }
-    const double dr = r2 - r02; // note that dr is the difference of the squares
+    const double dr =
+        r2 - r02;  // note that dr is the difference of the squares
     const double ir = 1.0 / dr;
     const double r02_ir = r02 * ir;
     const double C_ir_6 = _prfac * pos_int_pow<6>(r02_ir);
@@ -254,19 +257,19 @@ struct HS_WCA_interaction : BaseInteraction {
       return _infty;
     }
     const double coff =
-        dij *
-        (1.0 + _sca); // distance at which the soft cores are at contact
+        dij * (1.0 + _sca);  // distance at which the soft cores are at contact
     if (r2 > coff * coff) {
       *gij = 0.;
       return 0.;
     }
-    const double dr = r2 - r02; // note that dr is the difference of the squares
+    const double dr =
+        r2 - r02;  // note that dr is the difference of the squares
     const double ir = 1.0 / dr;
     const double r02_ir = r02 * ir;
     const double C_ir_6 = _prfac * pos_int_pow<6>(r02_ir);
     const double C_ir_12 = C_ir_6 * C_ir_6;
     *gij = _eps * (-48. * C_ir_6 + 96. * C_ir_12) *
-           ir; // this is -g/r, 1/dr because powers must be 7 and 13
+           ir;  // this is -g/r, 1/dr because powers must be 7 and 13
     return compute_energy(C_ir_6, C_ir_12);
   }
 
@@ -280,20 +283,20 @@ struct HS_WCA_interaction : BaseInteraction {
       return _infty;
     }
     const double coff =
-        dij *
-        (1.0 + _sca); // distance at which the soft cores are at contact
+        dij * (1.0 + _sca);  // distance at which the soft cores are at contact
     if (r2 > coff * coff) {
       *gij = 0.;
       *hij = 0.;
       return 0.;
     }
-    const double dr = r2 - r02; // note that dr is the difference of the squares
+    const double dr =
+        r2 - r02;  // note that dr is the difference of the squares
     const double ir = 1.0 / dr;
     const double r02_ir = r02 * ir;
     const double C_ir_6 = _prfac * pos_int_pow<6>(r02_ir);
     const double C_ir_12 = C_ir_6 * C_ir_6;
     *gij = _eps * (-48. * C_ir_6 + 96. * C_ir_12) *
-           ir; // this is -g/r, 1/dr because powers must be 7 and 13
+           ir;  // this is -g/r, 1/dr because powers must be 7 and 13
     *hij = -*gij + _eps * (-672. * C_ir_6 + 2496. * C_ir_12) * r2 * ir * ir;
     return compute_energy(C_ir_6, C_ir_12);
   }
@@ -337,7 +340,7 @@ struct HS_WCA_interaction : BaseInteraction {
 template <size_t ndim, size_t exp = 6>
 class HS_WCA : public SimplePairwisePotential<sf_HS_WCA_interaction<exp>,
                                               cartesian_distance<ndim>> {
-public:
+ public:
   HS_WCA(double eps, double sca, Array<double> radii)
       : SimplePairwisePotential<sf_HS_WCA_interaction<exp>,
                                 cartesian_distance<ndim>>(
@@ -352,7 +355,7 @@ template <size_t ndim, size_t exp = 6>
 class HS_WCAPeriodic
     : public SimplePairwisePotential<sf_HS_WCA_interaction<exp>,
                                      periodic_distance<ndim>> {
-public:
+ public:
   HS_WCAPeriodic(double eps, double sca, Array<double> radii,
                  Array<double> const boxvec)
       : SimplePairwisePotential<sf_HS_WCA_interaction<exp>,
@@ -368,7 +371,7 @@ template <size_t ndim, size_t exp = 6>
 class HS_WCALeesEdwards
     : public SimplePairwisePotential<sf_HS_WCA_interaction<exp>,
                                      leesedwards_distance<ndim>> {
-public:
+ public:
   HS_WCALeesEdwards(double eps, double sca, Array<double> radii,
                     Array<double> const boxvec, const double shear)
       : SimplePairwisePotential<sf_HS_WCA_interaction<exp>,
@@ -380,7 +383,7 @@ public:
 template <size_t ndim, size_t exp = 6>
 class HS_WCACellLists : public CellListPotential<sf_HS_WCA_interaction<exp>,
                                                  cartesian_distance<ndim>> {
-public:
+ public:
   HS_WCACellLists(double eps, double sca, Array<double> radii,
                   Array<double> const boxvec, const double ncellx_scale = 1.0,
                   const bool balance_omp = true)
@@ -388,7 +391,7 @@ public:
             std::make_shared<sf_HS_WCA_interaction<exp>>(eps, sca),
             std::make_shared<cartesian_distance<ndim>>(), boxvec,
             2 * (1 + sca) *
-                *std::max_element(radii.begin(), radii.end()), // rcut
+                *std::max_element(radii.begin(), radii.end()),  // rcut
             ncellx_scale, radii, sca, balance_omp) {
     if (boxvec.size() != ndim) {
       throw std::runtime_error("HS_WCA: illegal input: boxvec");
@@ -405,7 +408,7 @@ template <size_t ndim, size_t exp = 6>
 class HS_WCAPeriodicCellLists
     : public CellListPotential<sf_HS_WCA_interaction<exp>,
                                periodic_distance<ndim>> {
-public:
+ public:
   HS_WCAPeriodicCellLists(double eps, double sca, Array<double> radii,
                           Array<double> const boxvec,
                           const double ncellx_scale = 1.0,
@@ -414,7 +417,7 @@ public:
             std::make_shared<sf_HS_WCA_interaction<exp>>(eps, sca),
             std::make_shared<periodic_distance<ndim>>(boxvec), boxvec,
             2 * (1 + sca) *
-                *std::max_element(radii.begin(), radii.end()), // rcut
+                *std::max_element(radii.begin(), radii.end()),  // rcut
             ncellx_scale, radii, sca, balance_omp) {}
   size_t get_nr_unique_pairs() const {
     return CellListPotential<sf_HS_WCA_interaction<exp>,
@@ -430,7 +433,7 @@ template <size_t ndim, size_t exp = 6>
 class HS_WCALeesEdwardsCellLists
     : public CellListPotential<sf_HS_WCA_interaction<exp>,
                                leesedwards_distance<ndim>> {
-public:
+ public:
   HS_WCALeesEdwardsCellLists(double eps, double sca, Array<double> radii,
                              Array<double> const boxvec, const double shear,
                              const double ncellx_scale = 1.0,
@@ -440,7 +443,7 @@ public:
             std::make_shared<sf_HS_WCA_interaction<exp>>(eps, sca),
             std::make_shared<leesedwards_distance<ndim>>(boxvec, shear), boxvec,
             2 * (1 + sca) *
-                *std::max_element(radii.begin(), radii.end()), // rcut
+                *std::max_element(radii.begin(), radii.end()),  // rcut
             ncellx_scale, radii, sca, balance_omp) {}
   size_t get_nr_unique_pairs() const {
     return CellListPotential<sf_HS_WCA_interaction<exp>,
@@ -455,7 +458,7 @@ public:
 template <size_t exp = 6>
 class HS_WCANeighborList
     : public SimplePairwiseNeighborList<sf_HS_WCA_interaction<exp>> {
-public:
+ public:
   HS_WCANeighborList(Array<size_t> &ilist, double eps, double sca,
                      Array<double> radii)
       : SimplePairwiseNeighborList<sf_HS_WCA_interaction<exp>>(
@@ -463,5 +466,5 @@ public:
             radii) {}
 };
 
-} // namespace pele
-#endif //#ifndef _PELE_HS_WCA_H
+}  // namespace pele
+#endif  //#ifndef _PELE_HS_WCA_H

--- a/source/pele/inversepower.hpp
+++ b/source/pele/inversepower.hpp
@@ -94,7 +94,8 @@ struct InversePower_interaction : BaseInteraction {
   }
 };
 
-template <int POW> struct InverseIntPower_interaction : BaseInteraction {
+template <int POW>
+struct InverseIntPower_interaction : BaseInteraction {
   double const _eps;
   double const _pow;
 
@@ -147,7 +148,8 @@ template <int POW> struct InverseIntPower_interaction : BaseInteraction {
   }
 };
 
-template <int POW2> struct InverseHalfIntPower_interaction : BaseInteraction {
+template <int POW2>
+struct InverseHalfIntPower_interaction : BaseInteraction {
   double const _eps;
   double const _pow;
   InverseHalfIntPower_interaction(double eps) : _eps(eps), _pow(0.5 * POW2) {}
@@ -210,7 +212,7 @@ template <int POW2> struct InverseHalfIntPower_interaction : BaseInteraction {
 template <size_t ndim>
 class InversePower : public SimplePairwisePotential<InversePower_interaction,
                                                     cartesian_distance<ndim>> {
-public:
+ public:
   InversePower(double pow, double eps, pele::Array<double> const radii,
                bool exact_sum = false, double non_additivity = 0.0)
       : SimplePairwisePotential<InversePower_interaction,
@@ -224,7 +226,7 @@ template <size_t ndim>
 class InversePowerPeriodic
     : public SimplePairwisePotential<InversePower_interaction,
                                      periodic_distance<ndim>> {
-public:
+ public:
   InversePowerPeriodic(double pow, double eps, pele::Array<double> const radii,
                        pele::Array<double> const boxvec, bool exact_sum = false,
                        double non_additivity = 0.0)
@@ -236,14 +238,14 @@ public:
 };
 
 /**
-* Integer powers
-*/
+ * Integer powers
+ */
 
 template <size_t ndim, int POW>
 class InverseIntPower
     : public SimplePairwisePotential<InverseIntPower_interaction<POW>,
                                      cartesian_distance<ndim>> {
-public:
+ public:
   InverseIntPower(double eps, pele::Array<double> const radii,
                   bool exact_sum = false, double non_additivity = 0.0)
       : SimplePairwisePotential<InverseIntPower_interaction<POW>,
@@ -257,7 +259,7 @@ template <size_t ndim, int POW>
 class InverseIntPowerPeriodic
     : public SimplePairwisePotential<InverseIntPower_interaction<POW>,
                                      periodic_distance<ndim>> {
-public:
+ public:
   InverseIntPowerPeriodic(double eps, pele::Array<double> const radii,
                           pele::Array<double> const boxvec,
                           bool exact_sum = false, double non_additivity = 0.0)
@@ -276,7 +278,7 @@ template <size_t ndim, int POW2>
 class InverseHalfIntPower
     : public SimplePairwisePotential<InverseHalfIntPower_interaction<POW2>,
                                      cartesian_distance<ndim>> {
-public:
+ public:
   InverseHalfIntPower(double eps, pele::Array<double> const radii,
                       bool exact_sum = false, double non_additivity = 0.0)
       : SimplePairwisePotential<InverseHalfIntPower_interaction<POW2>,
@@ -290,16 +292,16 @@ template <size_t ndim, int POW2>
 class InverseHalfIntPowerPeriodic
     : public SimplePairwisePotential<InverseHalfIntPower_interaction<POW2>,
                                      periodic_distance<ndim>> {
-public:
+ public:
   InverseHalfIntPowerPeriodic(double eps, pele::Array<double> const radii,
                               pele::Array<double> const boxvec,
-                              bool exact_sum = false, double non_additivity = 0.0)
+                              bool exact_sum = false,
+                              double non_additivity = 0.0)
       : SimplePairwisePotential<InverseHalfIntPower_interaction<POW2>,
                                 periodic_distance<ndim>>(
             std::make_shared<InverseHalfIntPower_interaction<POW2>>(eps), radii,
             std::make_shared<periodic_distance<ndim>>(boxvec), 0.0, exact_sum,
-            non_additivity) {
-  }
+            non_additivity) {}
 };
 
 /*
@@ -322,16 +324,17 @@ template <size_t ndim>
 class InversePowerPeriodicCellLists
     : public CellListPotential<InversePower_interaction,
                                periodic_distance<ndim>> {
-public:
+ public:
   InversePowerPeriodicCellLists(double pow, double eps,
                                 pele::Array<double> const radii,
                                 pele::Array<double> const boxvec,
                                 const double ncellx_scale = 1.0,
-                                bool exact_sum = false, double non_additivity = 0.0)
+                                bool exact_sum = false,
+                                double non_additivity = 0.0)
       : CellListPotential<InversePower_interaction, periodic_distance<ndim>>(
             std::make_shared<InversePower_interaction>(pow, eps),
             std::make_shared<periodic_distance<ndim>>(boxvec), boxvec,
-            2.0 * (*std::max_element(radii.begin(), radii.end())), // rcut
+            2.0 * (*std::max_element(radii.begin(), radii.end())),  // rcut
             ncellx_scale, radii, 0.0, true, exact_sum, non_additivity) {}
 };
 
@@ -339,16 +342,17 @@ template <size_t ndim, int POW>
 class InverseIntPowerPeriodicCellLists
     : public CellListPotential<InverseIntPower_interaction<POW>,
                                periodic_distance<ndim>> {
-public:
+ public:
   InverseIntPowerPeriodicCellLists(double eps, pele::Array<double> const radii,
                                    pele::Array<double> const boxvec,
                                    const double ncellx_scale = 1.0,
-                                   bool exact_sum = false, double non_additivity = 0.0)
+                                   bool exact_sum = false,
+                                   double non_additivity = 0.0)
       : CellListPotential<InverseIntPower_interaction<POW>,
                           periodic_distance<ndim>>(
             std::make_shared<InverseIntPower_interaction<POW>>(eps),
             std::make_shared<periodic_distance<ndim>>(boxvec), boxvec,
-            2.0 * (*std::max_element(radii.begin(), radii.end())), // rcut,
+            2.0 * (*std::max_element(radii.begin(), radii.end())),  // rcut,
             ncellx_scale, radii, 0.0, true, exact_sum, non_additivity) {}
 };
 
@@ -356,7 +360,7 @@ template <size_t ndim, int POW2>
 class InverseHalfIntPowerPeriodicCellLists
     : public CellListPotential<InverseHalfIntPower_interaction<POW2>,
                                periodic_distance<ndim>> {
-public:
+ public:
   InverseHalfIntPowerPeriodicCellLists(double eps,
                                        pele::Array<double> const radii,
                                        pele::Array<double> const boxvec,
@@ -367,10 +371,10 @@ public:
                           periodic_distance<ndim>>(
             std::make_shared<InverseHalfIntPower_interaction<POW2>>(eps),
             std::make_shared<periodic_distance<ndim>>(boxvec), boxvec,
-            2.0 * (*std::max_element(radii.begin(), radii.end())), // rcut,
+            2.0 * (*std::max_element(radii.begin(), radii.end())),  // rcut,
             ncellx_scale, radii, 0.0, true, exact_sum, non_additivity) {}
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif //#ifndef _PELE_INVERSEPOWER_H
+#endif  //#ifndef _PELE_INVERSEPOWER_H

--- a/source/pele/inversepower_stillinger.hpp
+++ b/source/pele/inversepower_stillinger.hpp
@@ -17,8 +17,7 @@ struct InversePowerStillinger_interaction : BaseInteraction {
   }
   // calculate energy and gradient from distance squared, gradient is in
   // -(dv/drij)/|rij|
-  double energy_gradient(double r2, double *gij,
-                         const double dij) const {
+  double energy_gradient(double r2, double *gij, const double dij) const {
     const double E = power_inp2((dij * dij) / r2, m_pow);
     *gij = m_pow * E / r2;
     return E;
@@ -33,7 +32,8 @@ struct InversePowerStillinger_interaction : BaseInteraction {
 
   // Compute inp ** n.
   // See Skiena, p. 48.
-  template <class T> T power(const T inp, const size_t n) const {
+  template <class T>
+  T power(const T inp, const size_t n) const {
     if (n == 0) {
       return 1;
     }
@@ -45,7 +45,8 @@ struct InversePowerStillinger_interaction : BaseInteraction {
     }
   }
   // Compute inp ** n, given inp ** 2.
-  template <class T> T power_inp2(const T inp2, const size_t n) const {
+  template <class T>
+  T power_inp2(const T inp2, const size_t n) const {
     const T x = power(inp2, n / 2);
     if (n % 2) {
       return std::sqrt(inp2) * x;
@@ -59,7 +60,7 @@ template <size_t ndim>
 class InversePowerStillinger
     : public SimplePairwisePotential<InversePowerStillinger_interaction,
                                      cartesian_distance<ndim>> {
-public:
+ public:
   InversePowerStillinger(const size_t pow, const pele::Array<double> radii)
       : SimplePairwisePotential<InversePowerStillinger_interaction,
                                 cartesian_distance<ndim>>(
@@ -71,7 +72,7 @@ template <size_t ndim>
 class InversePowerStillingerPeriodic
     : public SimplePairwisePotential<InversePowerStillinger_interaction,
                                      periodic_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerPeriodic(const size_t pow,
                                  const pele::Array<double> radii,
                                  const pele::Array<double> boxvec)
@@ -81,6 +82,6 @@ public:
             std::make_shared<periodic_distance<ndim>>(boxvec)) {}
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef _PELE_INVERSEPOWER_STILLIGNER_H
+#endif  // #ifndef _PELE_INVERSEPOWER_STILLIGNER_H

--- a/source/pele/inversepower_stillinger_cut.hpp
+++ b/source/pele/inversepower_stillinger_cut.hpp
@@ -12,7 +12,9 @@ struct InversePowerStillinger_cut_interaction : BaseInteraction {
   // http://dx.doi.org/10.1063/1.449840
   const double m_pow, m_rcut, m_rcut2, m_q0, m_q1, m_q2;
   InversePowerStillinger_cut_interaction(const size_t pow, const double rcut)
-      : m_pow(pow), m_rcut(rcut), m_rcut2(m_rcut * m_rcut),
+      : m_pow(pow),
+        m_rcut(rcut),
+        m_rcut2(m_rcut * m_rcut),
         m_q0(-0.5 * (m_pow + 1) * (m_pow + 2) / std::pow(m_rcut, m_pow)),
         m_q1(m_pow * (m_pow + 2) / std::pow(m_rcut, m_pow + 1)),
         m_q2(-0.5 * m_pow * (m_pow + 1) / std::pow(m_rcut, m_pow + 2)) {}
@@ -27,8 +29,7 @@ struct InversePowerStillinger_cut_interaction : BaseInteraction {
   }
   // calculate energy and gradient from distance squared, gradient is in
   // -(dv/drij)/|rij|
-  double energy_gradient(double r2, double *gij,
-                         const double dij) const {
+  double energy_gradient(double r2, double *gij, const double dij) const {
     if (r2 > m_rcut2) {
       *gij = 0;
       return 0.;
@@ -58,7 +59,8 @@ struct InversePowerStillinger_cut_interaction : BaseInteraction {
 
   // Compute inp ** n.
   // See Skiena, p. 48.
-  template <class T> T power(const T inp, const size_t n) const {
+  template <class T>
+  T power(const T inp, const size_t n) const {
     if (n == 0) {
       return 1;
     }
@@ -70,7 +72,8 @@ struct InversePowerStillinger_cut_interaction : BaseInteraction {
     }
   }
   // Compute inp ** n, given inp ** 2.
-  template <class T> T power_inp2(const T inp2, const size_t n) const {
+  template <class T>
+  T power_inp2(const T inp2, const size_t n) const {
     const T x = power(inp2, n / 2);
     if (n % 2) {
       return std::sqrt(inp2) * x;
@@ -84,7 +87,7 @@ template <size_t ndim>
 class InversePowerStillingerCut
     : public SimplePairwisePotential<InversePowerStillinger_cut_interaction,
                                      cartesian_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerCut(const size_t pow, const pele::Array<double> radii,
                             double rcut)
       : SimplePairwisePotential<InversePowerStillinger_cut_interaction,
@@ -97,7 +100,7 @@ template <size_t ndim>
 class InversePowerStillingerCutPeriodic
     : public SimplePairwisePotential<InversePowerStillinger_cut_interaction,
                                      periodic_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerCutPeriodic(const size_t pow,
                                     const pele::Array<double> radii,
                                     double rcut,
@@ -112,7 +115,7 @@ template <size_t ndim>
 class InversePowerStillingerCutPeriodicCellLists
     : public CellListPotential<InversePowerStillinger_cut_interaction,
                                periodic_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerCutPeriodicCellLists(const size_t pow,
                                              const pele::Array<double> radii,
                                              double rcut,
@@ -125,6 +128,6 @@ public:
             ncellx_scale, radii) {}
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef _PELE_INVERSEPOWER_STILLIGNER_CUT_H
+#endif  // #ifndef _PELE_INVERSEPOWER_STILLIGNER_CUT_H

--- a/source/pele/inversepower_stillinger_cut_quad.hpp
+++ b/source/pele/inversepower_stillinger_cut_quad.hpp
@@ -4,15 +4,16 @@
 #ifndef INVERSE_POWER_STILINGER_CUT_QUAD_H
 #define INVERSE_POWER_STILINGER_CUT_QUAD_H
 
-#include "base_interaction.hpp"
-#include "pele/cell_list_potential.hpp"
-#include "pele/simple_pairwise_potential.hpp"
 #include <cmath>
 #include <cstddef>
 #include <iostream>
 #include <pele/meta_pow.hpp>
 #include <pele/pairwise_potential_interface.hpp>
 #include <stdexcept>
+
+#include "base_interaction.hpp"
+#include "pele/cell_list_potential.hpp"
+#include "pele/simple_pairwise_potential.hpp"
 
 namespace pele {
 
@@ -26,18 +27,19 @@ namespace pele {
 // and c0, c2, c4 are constants set based on the cutoff radius
 // the cutoff is going to be rcutoff = cutoff_factor * dij
 struct InversePowerStillingerQuadCutInteraction : BaseInteraction {
-
-  const int m_pow;               // potential goes as r^{-m_pow}'
-  const int m_pow_by_2;          // m_pow/2
-  const double m_cutoff_factor;  // cutoff factor rcut = m_cutoff_factor * dij
-  const double m_cutoff_factor2; // cutoff factor2 = cutoff_factor^2
-  const double c0;               // constant term in cutoff contribution
-  const double c2;               // quadratic term in cutoff contribution
-  const double c4;               // quartic term in cutoff contribution
-  const double m_v0;             // overall energy scale for the full potential
+  const int m_pow;                // potential goes as r^{-m_pow}'
+  const int m_pow_by_2;           // m_pow/2
+  const double m_cutoff_factor;   // cutoff factor rcut = m_cutoff_factor * dij
+  const double m_cutoff_factor2;  // cutoff factor2 = cutoff_factor^2
+  const double c0;                // constant term in cutoff contribution
+  const double c2;                // quadratic term in cutoff contribution
+  const double c4;                // quartic term in cutoff contribution
+  const double m_v0;              // overall energy scale for the full potential
   InversePowerStillingerQuadCutInteraction(const int pow, const double v0,
                                            const double cutoff_factor)
-      : m_pow(pow), m_pow_by_2(pow / 2), m_cutoff_factor(cutoff_factor),
+      : m_pow(pow),
+        m_pow_by_2(pow / 2),
+        m_cutoff_factor(cutoff_factor),
         m_cutoff_factor2(cutoff_factor * cutoff_factor),
         c0(-(1.0 / 8.0) * v0 * std::pow(m_cutoff_factor, -pow) *
            (8 + 6 * pow + pow * pow)),
@@ -48,15 +50,16 @@ struct InversePowerStillingerQuadCutInteraction : BaseInteraction {
         m_v0(v0) {
     if (pow % 2 != 0) {
       // not implemented for odd powers
-      throw std::runtime_error("InversePowerStillingerQuadCutInteraction: only "
-                               "implemented for even powers");
+      throw std::runtime_error(
+          "InversePowerStillingerQuadCutInteraction: only "
+          "implemented for even powers");
     }
   }
   double energy(const double r2, const double cutoff) const {
     if (r2 > cutoff * cutoff) {
       return 0;
     }
-    const double dij = cutoff/m_cutoff_factor;
+    const double dij = cutoff / m_cutoff_factor;
     const double r2_scaled = r2 / (dij * dij);
     const double r4_scaled = r2_scaled * r2_scaled;
     const double r_pow_scaled = std::pow(r2_scaled, m_pow_by_2);
@@ -70,7 +73,7 @@ struct InversePowerStillingerQuadCutInteraction : BaseInteraction {
       *gij = 0;
       return 0.;
     }
-    const double dij = cutoff/m_cutoff_factor;
+    const double dij = cutoff / m_cutoff_factor;
     const double dij_2 = dij * dij;
     const double r2_scaled = r2 / (dij_2);
     const double r4 = r2_scaled * r2_scaled;
@@ -88,7 +91,7 @@ struct InversePowerStillingerQuadCutInteraction : BaseInteraction {
       *hij = 0;
       return 0.;
     }
-    const double dij = cutoff/m_cutoff_factor;
+    const double dij = cutoff / m_cutoff_factor;
     const double dij_2 = dij * dij;
     const double r2_scaled = r2 / (dij_2);
     const double r4_scaled = r2_scaled * r2_scaled;
@@ -102,47 +105,49 @@ struct InversePowerStillingerQuadCutInteraction : BaseInteraction {
   }
 };
 
-
 /*
  * Templated potential for Stillinger-Weber potential with a cutoff.
-* This version is quicker because the power can be calculated faster when known at
-* compile time.
-*/
-template<int POW> struct InversePowerStillingerQuadCutInteractionInt : BaseInteraction {
-
-  const int m_pow;               // potential goes as r^{-m_pow}'
-  const int m_pow_by_2;          // m_pow/2
-  const double m_cutoff_factor;  // cutoff factor rcut = m_cutoff_factor * dij
-  const double m_cutoff_factor2; // cutoff factor2 = cutoff_factor^2
-  const double c0;               // constant term in cutoff contribution
-  const double c2;               // quadratic term in cutoff contribution
-  const double c4;               // quartic term in cutoff contribution
-  const double m_v0;             // overall energy scale for the full potential
+ * This version is quicker because the power can be calculated faster when known
+ * at compile time.
+ */
+template <int POW>
+struct InversePowerStillingerQuadCutInteractionInt : BaseInteraction {
+  const int m_pow;                // potential goes as r^{-m_pow}'
+  const int m_pow_by_2;           // m_pow/2
+  const double m_cutoff_factor;   // cutoff factor rcut = m_cutoff_factor * dij
+  const double m_cutoff_factor2;  // cutoff factor2 = cutoff_factor^2
+  const double c0;                // constant term in cutoff contribution
+  const double c2;                // quadratic term in cutoff contribution
+  const double c4;                // quartic term in cutoff contribution
+  const double m_v0;              // overall energy scale for the full potential
   InversePowerStillingerQuadCutInteractionInt(double v0,
-                                           const double cutoff_factor)
-      : m_pow(POW), m_pow_by_2(POW / 2), m_cutoff_factor(cutoff_factor),
+                                              const double cutoff_factor)
+      : m_pow(POW),
+        m_pow_by_2(POW / 2),
+        m_cutoff_factor(cutoff_factor),
         m_cutoff_factor2(cutoff_factor * cutoff_factor),
-        c0(-(  1.0 / 8.0) * v0 * std::pow(m_cutoff_factor, -POW) *
+        c0(-(1.0 / 8.0) * v0 * std::pow(m_cutoff_factor, -POW) *
            (8 + 6 * POW + POW * POW)),
-        c2((1.0 / 4.0) * v0 * std::pow(m_cutoff_factor, -POW- 2) *
+        c2((1.0 / 4.0) * v0 * std::pow(m_cutoff_factor, -POW - 2) *
            (4 * POW + POW * POW)),
         c4(-(1.0 / 8.0) * v0 * std::pow(m_cutoff_factor, -POW - 4) *
            (POW * POW + 2 * POW)),
         m_v0(v0) {
     if (POW % 2 != 0) {
       // not implemented for odd powers
-      throw std::runtime_error("InversePowerStillingerQuadCutInteractionInt: only "
-                               "implemented for even powers");
+      throw std::runtime_error(
+          "InversePowerStillingerQuadCutInteractionInt: only "
+          "implemented for even powers");
     }
   }
   double energy(const double r2, const double cutoff) const {
     if (r2 > cutoff * cutoff) {
       return 0;
     }
-    const double dij = cutoff/m_cutoff_factor;
+    const double dij = cutoff / m_cutoff_factor;
     const double r2_scaled = r2 / (dij * dij);
     const double r4_scaled = r2_scaled * r2_scaled;
-    const double r_pow_scaled = pos_int_pow<POW/2>(r2_scaled);
+    const double r_pow_scaled = pos_int_pow<POW / 2>(r2_scaled);
 
     return m_v0 / r_pow_scaled + c0 + c2 * r2_scaled + c4 * r4_scaled;
   }
@@ -153,11 +158,11 @@ template<int POW> struct InversePowerStillingerQuadCutInteractionInt : BaseInter
       *gij = 0;
       return 0.;
     }
-    const double dij = cutoff/m_cutoff_factor;
+    const double dij = cutoff / m_cutoff_factor;
     const double dij_2 = dij * dij;
     const double r2_scaled = r2 / (dij_2);
     const double r4 = r2_scaled * r2_scaled;
-    const double r_pow_scaled = pos_int_pow<POW/2>(r2_scaled);
+    const double r_pow_scaled = pos_int_pow<POW / 2>(r2_scaled);
 
     double e = m_v0 / r_pow_scaled + c0 + c2 * r2_scaled + c4 * r4;
     *gij = POW * m_v0 / (r_pow_scaled * r2) - 2 * c2 / dij_2 -
@@ -171,11 +176,11 @@ template<int POW> struct InversePowerStillingerQuadCutInteractionInt : BaseInter
       *hij = 0;
       return 0.;
     }
-    const double dij = cutoff/m_cutoff_factor;
+    const double dij = cutoff / m_cutoff_factor;
     const double dij_2 = dij * dij;
     const double r2_scaled = r2 / (dij_2);
     const double r4_scaled = r2_scaled * r2_scaled;
-    const double r_pow_scaled = pos_int_pow<POW/2>(r2_scaled);
+    const double r_pow_scaled = pos_int_pow<POW / 2>(r2_scaled);
     double e = m_v0 / r_pow_scaled + c0 + c2 * r2_scaled + c4 * r4_scaled;
     *gij = POW * m_v0 / (r_pow_scaled * r2) - 2 * c2 / dij_2 -
            4 * c4 * r2_scaled / (dij_2);
@@ -189,7 +194,7 @@ template <size_t ndim>
 class InversePowerStillingerCutQuad
     : public SimplePairwisePotential<InversePowerStillingerQuadCutInteraction,
                                      cartesian_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerCutQuad(const int pow, const double v0,
                                 const double cutoff_factor,
                                 const pele::Array<double> radii,
@@ -206,7 +211,7 @@ template <size_t ndim>
 class InversePowerStillingerCutQuadPeriodic
     : public SimplePairwisePotential<InversePowerStillingerQuadCutInteraction,
                                      periodic_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerCutQuadPeriodic(const int pow, const double v0,
                                         const double cutoff_factor,
                                         const pele::Array<double> radii,
@@ -216,15 +221,15 @@ public:
                                 periodic_distance<ndim>>(
             std::make_shared<InversePowerStillingerQuadCutInteraction>(
                 pow, v0, cutoff_factor),
-            radii, NonAdditiveCutoffCalculator(non_additivity, cutoff_factor), std::make_shared<periodic_distance<ndim>>(boxvec), 0.0,
-            false) {}
+            radii, NonAdditiveCutoffCalculator(non_additivity, cutoff_factor),
+            std::make_shared<periodic_distance<ndim>>(boxvec), 0.0, false) {}
 };
 
 template <size_t ndim>
 class InversePowerStillingerCutQuadPeriodicCellLists
     : public CellListPotential<InversePowerStillingerQuadCutInteraction,
                                periodic_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerCutQuadPeriodicCellLists(
       const int pow, const double v0, const double cutoff_factor,
       const pele::Array<double> radii, const pele::Array<double> boxvec,
@@ -234,21 +239,23 @@ public:
             std::make_shared<InversePowerStillingerQuadCutInteraction>(
                 pow, v0, cutoff_factor),
             std::make_shared<periodic_distance<ndim>>(boxvec), boxvec,
-            ncellx_scale, radii, NonAdditiveCutoffCalculator(non_additivity, cutoff_factor), 0.0, true, false) {}
+            ncellx_scale, radii,
+            NonAdditiveCutoffCalculator(non_additivity, cutoff_factor), 0.0,
+            true, false) {}
 };
-
 
 template <size_t ndim, size_t POW>
 class InversePowerStillingerCutQuadInt
-    : public SimplePairwisePotential<InversePowerStillingerQuadCutInteractionInt<POW>,
-                                     cartesian_distance<ndim>> {
-public:
-  InversePowerStillingerCutQuadInt(const double v0,
-                                const double cutoff_factor,
-                                const pele::Array<double> radii,
-                                double non_additivity = 0.0)
-      : SimplePairwisePotential<InversePowerStillingerQuadCutInteractionInt<POW>,
-                                cartesian_distance<ndim>>(
+    : public SimplePairwisePotential<
+          InversePowerStillingerQuadCutInteractionInt<POW>,
+          cartesian_distance<ndim>> {
+ public:
+  InversePowerStillingerCutQuadInt(const double v0, const double cutoff_factor,
+                                   const pele::Array<double> radii,
+                                   double non_additivity = 0.0)
+      : SimplePairwisePotential<
+            InversePowerStillingerQuadCutInteractionInt<POW>,
+            cartesian_distance<ndim>>(
             std::make_shared<InversePowerStillingerQuadCutInteractionInt<POW>>(
                 v0, cutoff_factor),
             radii, NonAdditiveCutoffCalculator(non_additivity, cutoff_factor),
@@ -257,27 +264,29 @@ public:
 
 template <size_t ndim, size_t POW>
 class InversePowerStillingerCutQuadIntPeriodic
-    : public SimplePairwisePotential<InversePowerStillingerQuadCutInteractionInt<POW>,
-                                     periodic_distance<ndim>> {
-public:
+    : public SimplePairwisePotential<
+          InversePowerStillingerQuadCutInteractionInt<POW>,
+          periodic_distance<ndim>> {
+ public:
   InversePowerStillingerCutQuadIntPeriodic(const double v0,
-                                        const double cutoff_factor,
-                                        const pele::Array<double> radii,
-                                        const pele::Array<double> boxvec,
-                                        double non_additivity = 0.0)
-      : SimplePairwisePotential<InversePowerStillingerQuadCutInteractionInt<POW>,
-                                periodic_distance<ndim>>(
+                                           const double cutoff_factor,
+                                           const pele::Array<double> radii,
+                                           const pele::Array<double> boxvec,
+                                           double non_additivity = 0.0)
+      : SimplePairwisePotential<
+            InversePowerStillingerQuadCutInteractionInt<POW>,
+            periodic_distance<ndim>>(
             std::make_shared<InversePowerStillingerQuadCutInteractionInt<POW>>(
                 v0, cutoff_factor),
-            radii, NonAdditiveCutoffCalculator(non_additivity, cutoff_factor), std::make_shared<periodic_distance<ndim>>(boxvec), 0.0,
-            false) {}
+            radii, NonAdditiveCutoffCalculator(non_additivity, cutoff_factor),
+            std::make_shared<periodic_distance<ndim>>(boxvec), 0.0, false) {}
 };
 
 template <size_t ndim, size_t POW>
 class InversePowerStillingerCutQuadIntPeriodicCellLists
     : public CellListPotential<InversePowerStillingerQuadCutInteractionInt<POW>,
                                periodic_distance<ndim>> {
-public:
+ public:
   InversePowerStillingerCutQuadIntPeriodicCellLists(
       const double v0, const double cutoff_factor,
       const pele::Array<double> radii, const pele::Array<double> boxvec,
@@ -287,9 +296,11 @@ public:
             std::make_shared<InversePowerStillingerQuadCutInteractionInt<POW>>(
                 v0, cutoff_factor),
             std::make_shared<periodic_distance<ndim>>(boxvec), boxvec,
-            ncellx_scale, radii, NonAdditiveCutoffCalculator(non_additivity, cutoff_factor), 0.0, true, false) {}
+            ncellx_scale, radii,
+            NonAdditiveCutoffCalculator(non_additivity, cutoff_factor), 0.0,
+            true, false) {}
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // !INVERSE_POWER_STILINGER_CUT_QUAD_H
+#endif  // !INVERSE_POWER_STILINGER_CUT_QUAD_H

--- a/source/pele/lbfgs.hpp
+++ b/source/pele/lbfgs.hpp
@@ -1,13 +1,14 @@
 #ifndef _PELE_LBFGS_H__
 #define _PELE_LBFGS_H__
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "optimizer.hpp"
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <vector>
+
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "optimizer.hpp"
 
 namespace pele {
 
@@ -16,7 +17,7 @@ namespace pele {
  * Implementation uses a backtracking linesearch.
  */
 class LBFGS : public GradientOptimizer {
-private:
+ private:
   int M_;               /**< The length of the LBFGS memory */
   double max_f_rise_;   /**< The maximum the function is allowed to rise in a
                          * given step.  This is the criterion for the
@@ -44,18 +45,18 @@ private:
   double H0_;
   int k_; /**< Counter for how many times the memory has been updated */
 
-  Array<double> alpha; //!< Alpha used when looping through LBFGS memory
+  Array<double> alpha;  //!< Alpha used when looping through LBFGS memory
 
-  Array<double> xold; //!< Coordinates before taking a step
-  Array<double> gold; //!< Gradient before taking a step
-  Array<double> step; //!< Step size and direction
+  Array<double> xold;  //!< Coordinates before taking a step
+  Array<double> gold;  //!< Gradient before taking a step
+  Array<double> step;  //!< Step size and direction
   double
-      inv_sqrt_size; //!< The inverse square root the the number of components
+      inv_sqrt_size;  //!< The inverse square root the the number of components
 #if PRINT_TO_FILE == 1
   std::ofstream trajectory_file;
 #endif
 
-public:
+ public:
   /**
    * Constructor
    */
@@ -100,7 +101,7 @@ public:
    */
   virtual void reset(pele::Array<double> &x0);
 
-private:
+ private:
   /**
    * Add a step to the LBFGS Memory
    * This updates s_, y_, rho_, H0_, and k_
@@ -120,6 +121,6 @@ private:
    */
   double backtracking_linesearch(Array<double> step);
 };
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/lbfgs_exact.hpp
+++ b/source/pele/lbfgs_exact.hpp
@@ -1,12 +1,13 @@
 #ifndef _PELE_LBFGS_H__
 #define _PELE_LBFGS_H__
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "optimizer.hpp"
 #include <memory>
 #include <mpreal.h>
 #include <vector>
+
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "optimizer.hpp"
 
 namespace pele {
 
@@ -18,7 +19,7 @@ using mpfr::mpreal;
 const int digits = 100;
 mpreal::set_default_prec(mpfr::digits2bits(digits)) class LBFGS_Exact
     : public GradientOptimizer {
-private:
+ private:
   int M_;               /**< The length of the LBFGS memory */
   double max_f_rise_;   /**< The maximum the function is allowed to rise in a
                          * given step.  This is the criterion for the
@@ -46,15 +47,15 @@ private:
   mpreal H0_;
   mpreal k_; /**< Counter for how many times the memory has been updated */
 
-  Array<mpreal> alpha; //!< Alpha used when looping through LBFGS memory
+  Array<mpreal> alpha;  //!< Alpha used when looping through LBFGS memory
 
-  Array<mpreal> xold; //!< Coordinates before taking a step
-  Array<mpreal> gold; //!< Gradient before taking a step
-  Array<mpreal> step; //!< Step size and direction
+  Array<mpreal> xold;  //!< Coordinates before taking a step
+  Array<mpreal> gold;  //!< Gradient before taking a step
+  Array<mpreal> step;  //!< Step size and direction
   double
-      inv_sqrt_size; //!< The inverse square root the the number of components
+      inv_sqrt_size;  //!< The inverse square root the the number of components
 
-public:
+ public:
   /**
    * Constructor-
    */
@@ -95,7 +96,7 @@ public:
    */
   virtual void reset(pele::Array<double> &x0);
 
-private:
+ private:
   /**
    * Add a step to the LBFGS Memory
    * This updates s_, y_, rho_, H0_, and k_
@@ -115,6 +116,6 @@ private:
    */
   double backtracking_linesearch(Array<mpreal> step);
 };
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/linesearch.hpp
+++ b/source/pele/linesearch.hpp
@@ -10,11 +10,12 @@
  *
  */
 
+#include <memory>
+#include <vector>
+
 #include "array.hpp"
 #include "base_potential.hpp"
 #include "optimizer.hpp"
-#include <memory>
-#include <vector>
 
 namespace pele {
 
@@ -23,8 +24,7 @@ namespace pele {
  * methods should ideally derive from this class
  */
 class LineSearch {
-
-protected:
+ protected:
   // // stored energy and gradient at the computed stepsize
   Array<double> end_gradient;
   double end_energy;
@@ -34,7 +34,7 @@ protected:
   // Optimizer class
   GradientOptimizer *opt_;
 
-public:
+ public:
   LineSearch(GradientOptimizer *opt, double max_stepnorm)
       : opt_(opt), max_stepnorm_(max_stepnorm){};
   virtual ~LineSearch(){};
@@ -61,17 +61,19 @@ public:
  */
 
 class OldLineSearch : public LineSearch {
-public:
+ public:
   OldLineSearch(GradientOptimizer *opt, double maxstepnorm,
                 double max_f_rise = 1e-4, double nred_max = 10,
                 bool use_relative_f = true)
-      : LineSearch(opt, maxstepnorm), max_f_rise_(max_f_rise),
-        nred_max_(nred_max), use_relative_f_(use_relative_f),
+      : LineSearch(opt, maxstepnorm),
+        max_f_rise_(max_f_rise),
+        nred_max_(nred_max),
+        use_relative_f_(use_relative_f),
         verbosity_(opt->get_verbosity_()){
 
         };
 
-private:
+ private:
   // maximum the function can rise to
   double max_f_rise_;
   // maximum number of backtracking iterations
@@ -93,7 +95,7 @@ private:
   // specify opt is gradient optimizer This ends up giving me a version of this
   // with version
 
-public:
+ public:
   // I'm putting this here instead of putting it elsewhere since I ended up
   // getting an undefined symbol error which means there are some linker issues?
   double line_search(Array<double> &x, Array<double> step);
@@ -111,6 +113,6 @@ public:
   inline void set_g_f_ptr(Array<double> &g) { g_ = g; };
 };
 
-} // namespace pele
+}  // namespace pele
 
 #endif /* End line search methods */

--- a/source/pele/lj.hpp
+++ b/source/pele/lj.hpp
@@ -13,13 +13,14 @@
 #ifndef PYGMIN_LJ_H
 #define PYGMIN_LJ_H
 
+#include <memory>
+
 #include "atomlist_potential.hpp"
 #include "base_interaction.hpp"
 #include "distance.hpp"
 #include "frozen_atoms.hpp"
 #include "simple_pairwise_ilist.hpp"
 #include "simple_pairwise_potential.hpp"
-#include <memory>
 
 namespace pele {
 
@@ -27,15 +28,19 @@ namespace pele {
  * Pairwise interaction for lennard jones
  */
 struct lj_interaction : BaseInteraction {
-private:
+ private:
   double const _C6, _C12;
   double const _6C6, _12C12;
   double const _42C6, _156C12;
 
-public:
+ public:
   lj_interaction(double C6, double C12)
-      : _C6(C6), _C12(C12), _6C6(6. * _C6), _12C12(12. * _C12),
-        _42C6(42. * _C6), _156C12(156. * _C12) {}
+      : _C6(C6),
+        _C12(C12),
+        _6C6(6. * _C6),
+        _12C12(12. * _C12),
+        _42C6(42. * _C6),
+        _156C12(156. * _C12) {}
 
   /* calculate energy from distance squared */
   double inline energy(double r2, const double dij) const {
@@ -78,7 +83,7 @@ public:
  * Pairwise Lennard-Jones potential
  */
 class LJ : public SimplePairwisePotential<lj_interaction> {
-public:
+ public:
   LJ(double C6, double C12)
       : SimplePairwisePotential<lj_interaction>(
             std::make_shared<lj_interaction>(C6, C12)) {}
@@ -89,7 +94,7 @@ public:
  */
 class LJPeriodic
     : public SimplePairwisePotential<lj_interaction, periodic_distance<3>> {
-public:
+ public:
   LJPeriodic(double C6, double C12, Array<double> const boxvec)
       : SimplePairwisePotential<lj_interaction, periodic_distance<3>>(
             std::make_shared<lj_interaction>(C6, C12),
@@ -100,10 +105,10 @@ public:
  * Pairwise Lennard-Jones potential with interaction lists
  */
 class LJNeighborList : public SimplePairwiseNeighborList<lj_interaction> {
-public:
+ public:
   LJNeighborList(Array<size_t> &ilist, double C6, double C12)
       : SimplePairwiseNeighborList<lj_interaction>(
             std::make_shared<lj_interaction>(C6, C12), ilist) {}
 };
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/lj_cut.hpp
+++ b/source/pele/lj_cut.hpp
@@ -25,8 +25,13 @@ struct lj_interaction_cut_smooth : BaseInteraction {
   double const _A2;
   double const _2A2;
   lj_interaction_cut_smooth(double C6, double C12, double rcut)
-      : _C6(C6), _C12(C12), _6C6(6. * _C6), _12C12(12. * _C12),
-        _42C6(42. * _C6), _156C12(156. * _C12), _rcut2(rcut * rcut),
+      : _C6(C6),
+        _C12(C12),
+        _6C6(6. * _C6),
+        _12C12(12. * _C12),
+        _42C6(42. * _C6),
+        _156C12(156. * _C12),
+        _rcut2(rcut * rcut),
         // A0 = 4.0*(sig**6/rcut**6) - 7.0*(sig**12/rcut**12)
         _A0(4. * _C6 / (_rcut2 * _rcut2 * _rcut2) -
             7. * _C12 / (_rcut2 * _rcut2 * _rcut2 * _rcut2 * _rcut2 * _rcut2)),
@@ -85,7 +90,7 @@ struct lj_interaction_cut_smooth : BaseInteraction {
  * Pairwise Lennard-Jones potential with smooth cutoff
  */
 class LJCut : public SimplePairwisePotential<lj_interaction_cut_smooth> {
-public:
+ public:
   LJCut(double C6, double C12, double rcut)
       : SimplePairwisePotential<lj_interaction_cut_smooth>(
             std::make_shared<lj_interaction_cut_smooth>(C6, C12, rcut)) {}
@@ -96,7 +101,7 @@ public:
  */
 class LJCutPeriodic : public SimplePairwisePotential<lj_interaction_cut_smooth,
                                                      periodic_distance<3>> {
-public:
+ public:
   LJCutPeriodic(double C6, double C12, double rcut, Array<double> const boxvec)
       : SimplePairwisePotential<lj_interaction_cut_smooth,
                                 periodic_distance<3>>(
@@ -110,7 +115,7 @@ public:
  */
 class LJCutAtomList : public AtomListPotential<lj_interaction_cut_smooth,
                                                cartesian_distance<3>> {
-public:
+ public:
   LJCutAtomList(double C6, double C12, double rcut, Array<size_t> atoms1,
                 Array<size_t> atoms2)
       : AtomListPotential<lj_interaction_cut_smooth, cartesian_distance<3>>(
@@ -130,7 +135,7 @@ public:
 class LJCutPeriodicAtomList
     : public AtomListPotential<lj_interaction_cut_smooth,
                                periodic_distance<3>> {
-public:
+ public:
   LJCutPeriodicAtomList(double C6, double C12, double rcut,
                         pele::Array<double> boxvec, Array<size_t> atoms1,
                         Array<size_t> atoms2)
@@ -153,7 +158,7 @@ template <size_t ndim>
 class LJCutPeriodicCellLists
     : public CellListPotential<lj_interaction_cut_smooth,
                                periodic_distance<ndim>> {
-public:
+ public:
   LJCutPeriodicCellLists(double c6, double c12, double rcut,
                          Array<double> const boxvec, double ncellx_scale)
       : CellListPotential<lj_interaction_cut_smooth, periodic_distance<ndim>>(
@@ -162,6 +167,6 @@ public:
             ncellx_scale) {}
 };
 
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/lowest_eig_potential.hpp
+++ b/source/pele/lowest_eig_potential.hpp
@@ -1,12 +1,13 @@
 #ifndef _PELE_LOWEST_EIG_POTENTIAL_H
 #define _PELE_LOWEST_EIG_POTENTIAL_H
 
-#include "array.hpp"
-#include "base_potential.hpp"
 #include <algorithm>
 #include <cmath>
 #include <memory>
 #include <vector>
+
+#include "array.hpp"
+#include "base_potential.hpp"
 
 namespace pele {
 
@@ -15,7 +16,7 @@ inline void zero_modes_translational(std::vector<pele::Array<double>> &zev,
   double v = 1 / sqrt(natoms);
   size_t N = natoms * bdim;
   for (size_t i = 0; i < bdim; ++i) {
-    pele::Array<double> evec(N, 0); // initialize array of zeros
+    pele::Array<double> evec(N, 0);  // initialize array of zeros
     for (size_t j = i; j < N; j += bdim) {
       evec[j] = v;
     }
@@ -24,19 +25,19 @@ inline void zero_modes_translational(std::vector<pele::Array<double>> &zev,
 }
 
 class Orthogonalize {
-public:
+ public:
   virtual ~Orthogonalize(){};
   virtual void orthogonalize(Array<double> const &coords,
                              Array<double> &vector) = 0;
 };
 
 class OrthogonalizeTranslational : public Orthogonalize {
-protected:
+ protected:
   std::vector<pele::Array<double>> _tr_evec;
   size_t _natoms, _bdim, _ndim;
   double _d, _tol;
 
-public:
+ public:
   // OrthogonalizeTranslational(size_t natoms, size_t bdim, double tol=1e-6);
   OrthogonalizeTranslational(size_t natoms, size_t bdim, double tol = 1e-6)
       : _natoms(natoms), _bdim(bdim), _ndim(bdim * natoms), _tol(tol) {
@@ -78,7 +79,7 @@ public:
     }
   }
 
-}; // class OrthogonalizeTranslational
+};  // class OrthogonalizeTranslational
 
 /*
  * Lowest Eigenvalue Potential:
@@ -88,24 +89,30 @@ public:
  * */
 
 class LowestEigPotential : public BasePotential {
-protected:
+ protected:
   std::shared_ptr<pele::BasePotential> _potential;
   pele::Array<double> _coords, _coordsd, _g, _gd;
   size_t _bdim, _natoms;
   double _d;
   OrthogonalizeTranslational _orthog;
   pele::Array<double>
-      x_opt; //!< Points to the coordinates used in the optimizer
-public:
+      x_opt;  //!< Points to the coordinates used in the optimizer
+ public:
   // LowestEigPotential(std::shared_ptr<pele::BasePotential> potential,
   // pele::Array<double>
   //         coords, size_t bdim, double d=1e-6);
   /*constructor*/
   LowestEigPotential(std::shared_ptr<pele::BasePotential> potential,
                      pele::Array<double> coords, size_t bdim, double d = 1e-6)
-      : _potential(potential), _coords(coords.copy()), _coordsd(coords.size()),
-        _g(_coords.size()), _gd(_coords.size()), _bdim(bdim),
-        _natoms(_coords.size() / _bdim), _d(d), _orthog(_natoms, _bdim),
+      : _potential(potential),
+        _coords(coords.copy()),
+        _coordsd(coords.size()),
+        _g(_coords.size()),
+        _gd(_coords.size()),
+        _bdim(bdim),
+        _natoms(_coords.size() / _bdim),
+        _d(d),
+        _orthog(_natoms, _bdim),
         x_opt(coords) {
     _potential->get_energy_gradient(_coords, _g);
   }
@@ -124,7 +131,7 @@ public:
           "set_x_opt to pass a pointer.");
     }
     _orthog.orthogonalize(
-        _coords, x_opt); // takes care of orthogonalizing and normalizing x_opt
+        _coords, x_opt);  // takes care of orthogonalizing and normalizing x_opt
 
     for (size_t i = 0; i < x_opt.size(); i++) {
       _coordsd[i] = _coords[i] + _d * x_opt[i];
@@ -150,7 +157,7 @@ public:
           "Use set_x_opt to pass a pointer.");
     }
     _orthog.orthogonalize(
-        _coords, x_opt); // takes care of orthogonalizing and normalizing x_opt
+        _coords, x_opt);  // takes care of orthogonalizing and normalizing x_opt
 
     for (size_t i = 0; i < x_opt.size(); i++) {
       _coordsd[i] = _coords[i] + _d * x_opt[i];
@@ -173,6 +180,6 @@ public:
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif //#ifndef _PELE_LOWEST_EIG_POTENTIAL_H
+#endif  //#ifndef _PELE_LOWEST_EIG_POTENTIAL_H

--- a/source/pele/lsparameters.hpp
+++ b/source/pele/lsparameters.hpp
@@ -72,7 +72,7 @@ enum LINE_SEARCH_TERMINATION_CONDITION {
 /// Parameters to control the L-BFGS algorithm.
 ///
 class LBFGSParam {
-public:
+ public:
   ///
   /// The number of corrections to approximate the inverse Hessian matrix.
   /// The L-BFGS routine stores the computation results of previous \ref m
@@ -162,7 +162,7 @@ public:
   // The linesearch condition for termination
   int linesearch;
 
-public:
+ public:
   ///
   /// Constructor for L-BFGS parameters.
   /// Default values for parameters will be set when the object is created.
@@ -174,9 +174,16 @@ public:
              Scalar min_step_ = Scalar(1e-20), Scalar max_step_ = Scalar(1e+20),
              Scalar ftol_ = Scalar(1e-4), Scalar wolfe_ = Scalar(0.9),
              int linesearch_ = LINESEARCH_BACKTRACKING_STRONG_WOLFE)
-      : m(m_), epsilon(epsilon_), epsilon_rel(epsilon_rel_), past(past_),
-        delta(delta_), max_linesearch(max_linesearch_), min_step(min_step_),
-        max_step(max_step_), ftol(ftol_), wolfe(wolfe_),
+      : m(m_),
+        epsilon(epsilon_),
+        epsilon_rel(epsilon_rel_),
+        past(past_),
+        delta(delta_),
+        max_linesearch(max_linesearch_),
+        min_step(min_step_),
+        max_step(max_step_),
+        ftol(ftol_),
+        wolfe(wolfe_),
         linesearch(linesearch_) {}
 
   ///
@@ -185,16 +192,13 @@ public:
   /// is invalid.
   ///
   inline void check_param() const {
-    if (m <= 0)
-      throw std::invalid_argument("'m' must be positive");
+    if (m <= 0) throw std::invalid_argument("'m' must be positive");
     if (epsilon < 0)
       throw std::invalid_argument("'epsilon' must be non-negative");
     if (epsilon_rel < 0)
       throw std::invalid_argument("'epsilon_rel' must be non-negative");
-    if (past < 0)
-      throw std::invalid_argument("'past' must be non-negative");
-    if (delta < 0)
-      throw std::invalid_argument("'delta' must be non-negative");
+    if (past < 0) throw std::invalid_argument("'past' must be non-negative");
+    if (delta < 0) throw std::invalid_argument("'delta' must be non-negative");
     if (max_iterations < 0)
       throw std::invalid_argument("'max_iterations' must be non-negative");
     throw std::invalid_argument(
@@ -212,6 +216,6 @@ public:
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // LINE_SEARCH_NOCEDAL_WRIGHT_H
+#endif  // LINE_SEARCH_NOCEDAL_WRIGHT_H

--- a/source/pele/matrix.hpp
+++ b/source/pele/matrix.hpp
@@ -9,8 +9,9 @@ namespace pele {
  * temporarily.  The idea is to redo something like the reshape() function in
  * numpy.
  */
-template <typename dtype> class MatrixAdapter : public pele::Array<dtype> {
-public:
+template <typename dtype>
+class MatrixAdapter : public pele::Array<dtype> {
+ public:
   /**
    * the second dimension of the matrix, e.g. the number of colums
    *
@@ -118,16 +119,14 @@ std::ostream &operator<<(std::ostream &out,
   size_t const M = a.shape().second;
   for (size_t n = 0; n < N; ++n) {
     for (size_t m = 0; m < M; ++m) {
-      if (m > 0)
-        out << ", ";
+      if (m > 0) out << ", ";
       out << a(n, m);
     }
-    if (n < N - 1)
-      out << ",\n  ";
+    if (n < N - 1) out << ",\n  ";
   }
   out << " ]";
   return out;
 }
 
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/meta_pow.hpp
+++ b/source/pele/meta_pow.hpp
@@ -13,58 +13,66 @@
  *http://stackoverflow.com/questions/16443682/c-power-of-integer-template-meta-programming
  **/
 
-#include <cmath>       //for sqrt in half powers
-#include <type_traits> //for static asserts
+#include <cmath>        //for sqrt in half powers
+#include <type_traits>  //for static asserts
 
 namespace pele {
 
-template <class T, int N> struct meta_pow {
+template <class T, int N>
+struct meta_pow {
   static T f(const T x) { return meta_pow<T, N - 1>::f(x) * x; }
 };
 
-template <class T> struct meta_pow<T, 12> {
+template <class T>
+struct meta_pow<T, 12> {
   static T f(const T x) {
     T x4 = meta_pow<T, 4>::f(x);
     return x4 * x4 * x4;
   }
 };
 
-template <class T> struct meta_pow<T, 10> {
+template <class T>
+struct meta_pow<T, 10> {
   static T f(const T x) {
     T x5 = meta_pow<T, 5>::f(x);
     return x5 * x5;
   }
 };
 
-template <class T> struct meta_pow<T, 9> {
+template <class T>
+struct meta_pow<T, 9> {
   static T f(const T x) {
     T x3 = x * x * x;
     return x3 * x3 * x3;
   }
 };
 
-template <class T> struct meta_pow<T, 8> {
+template <class T>
+struct meta_pow<T, 8> {
   static T f(const T x) {
     T x4 = meta_pow<T, 4>::f(x);
     return x4 * x4;
   }
 };
 
-template <class T> struct meta_pow<T, 6> {
+template <class T>
+struct meta_pow<T, 6> {
   static T f(const T x) {
     T x3 = x * x * x;
     return x3 * x3;
   }
 };
 
-template <class T> struct meta_pow<T, 4> {
+template <class T>
+struct meta_pow<T, 4> {
   static T f(const T x) {
     T x2 = x * x;
     return x2 * x2;
   }
 };
 
-template <class T> struct meta_pow<T, 0> {
+template <class T>
+struct meta_pow<T, 0> {
   static T f(const T x) { return T(1); }
 };
 
@@ -72,7 +80,8 @@ template <class T> struct meta_pow<T, 0> {
  * pow(x, N) where N >= 0, integer
  * usage: pos_int_pow<N>(x)
  */
-template <int N, class T> inline T pos_int_pow(const T x) {
+template <int N, class T>
+inline T pos_int_pow(const T x) {
   static_assert(N >= 0, "illegal exponent input");
   return meta_pow<T, N>::f(x);
 }
@@ -81,7 +90,8 @@ template <int N, class T> inline T pos_int_pow(const T x) {
  * pow(x, - N) where N >= 0, integer
  * usage: neg_int_pow<-N>(x)
  */
-template <int N, class T> inline T neg_int_pow(const T x) {
+template <int N, class T>
+inline T neg_int_pow(const T x) {
   static_assert(N <= 0, "illegal exponent input");
   return T(1) / meta_pow<T, -N>::f(x);
 }
@@ -90,7 +100,8 @@ template <int N, class T> inline T neg_int_pow(const T x) {
  * pow(x, N / 2) where N >= 0, integer
  * usage: pos_half_int_pow<N>(x)
  */
-template <int N, class T> inline T pos_half_int_pow(const T x) {
+template <int N, class T>
+inline T pos_half_int_pow(const T x) {
   static_assert(N >= 0, "illegal exponent input");
   return std::sqrt(meta_pow<T, N>::f(x));
 }
@@ -99,11 +110,12 @@ template <int N, class T> inline T pos_half_int_pow(const T x) {
  * pow(x, - N / 2) where N >= 0, integer
  * usage: neg_half_int_pow<-N>(x)
  */
-template <int N, class T> inline T neg_half_int_pow(const T x) {
+template <int N, class T>
+inline T neg_half_int_pow(const T x) {
   static_assert(N <= 0, "illegal exponent input");
   return T(1) / std::sqrt(meta_pow<T, -N>::f(x));
 }
 
-} // namespace pele
+}  // namespace pele
 
-#endif //#ifndef _PELE_META_POW_H
+#endif  //#ifndef _PELE_META_POW_H

--- a/source/pele/modified_fire.hpp
+++ b/source/pele/modified_fire.hpp
@@ -72,7 +72,7 @@ class MODIFIED_FIRE : public ODEBasedOptimizer {
                 double maxstep, size_t Nmin = 5, double finc = 1.1,
                 double fdec = 0.5, double fa = 0.99, double astart = 0.1,
                 double tol = 1e-4, bool stepback = true,
-                bool save_trajectory = false);
+                bool save_trajectory = false, int iterations_before_save = 1);
   /**
    * Destructor
    */

--- a/source/pele/modified_fire.hpp
+++ b/source/pele/modified_fire.hpp
@@ -1,14 +1,15 @@
 #ifndef _PELE_MODIFIED_FIRE_H__
 #define _PELE_MODIFIED_FIRE_H__
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "optimizer.hpp"
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <ostream>
 #include <stdexcept>
+
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "optimizer.hpp"
 
 namespace pele {
 /**
@@ -48,7 +49,7 @@ namespace pele {
  */
 
 class MODIFIED_FIRE : public ODEBasedOptimizer {
-private:
+ private:
   double _dtstart, _dt, _dtmax, _maxstep, _Nmin, _finc, _fdec, _fa, _astart, _a,
       _fold, _ifnorm, _vnorm;
   pele::Array<double> _v, _dx, _xold, _gold;
@@ -62,7 +63,7 @@ private:
   std::ofstream gradient_file;
 #endif
 
-public:
+ public:
   /**
    * Constructor
    */
@@ -70,7 +71,8 @@ public:
                 pele::Array<double> &x0, double dtstart, double dtmax,
                 double maxstep, size_t Nmin = 5, double finc = 1.1,
                 double fdec = 0.5, double fa = 0.99, double astart = 0.1,
-                double tol = 1e-4, bool stepback = true, bool save_trajectory = false);
+                double tol = 1e-4, bool stepback = true,
+                bool save_trajectory = false);
   /**
    * Destructor
    */
@@ -132,23 +134,23 @@ inline void MODIFIED_FIRE::_VelocityVerlet_integration() {
   }
   for (size_t i = 0; i < _N; ++i) {
     _v[i] -=
-        0.5 * _dt * (_gold[i] + g_[i]); // update velocity assumes all masses 1
+        0.5 * _dt * (_gold[i] + g_[i]);  // update velocity assumes all masses 1
     _dx[i] =
         _dt *
         (_v[i] -
-         0.5 * _dt * g_[i]); // build displacement vector, assumes all masses 1
+         0.5 * _dt * g_[i]);  // build displacement vector, assumes all masses 1
   }
-  _gold.assign(g_); // save gradient as old g
+  _gold.assign(g_);  // save gradient as old g
   double normdx = compute_pot_norm(_dx);
 
   if (normdx > _maxstep) {
     _dx *= (_maxstep /
-            normdx); // resize displacement vector is greater than _maxstep
+            normdx);  // resize displacement vector is greater than _maxstep
   }
 
   x_ += _dx;
 
-  f_ = potential_->get_energy_gradient(x_, g_); // update gradient
+  f_ = potential_->get_energy_gradient(x_, g_);  // update gradient
 }
 
 inline void MODIFIED_FIRE::_ForwardEuler_integration() {
@@ -156,22 +158,22 @@ inline void MODIFIED_FIRE::_ForwardEuler_integration() {
    * the gradients rather than the forces appear in the expression
    */
   for (size_t i = 0; i < _N;
-       ++i) { // this was after get_energy_gradient, moved for testing
-    _v[i] -= _dt * g_[i]; // update velocity, assumes all masses are 1
-    _dx[i] = _dt * _v[i]; // build displacement vector
+       ++i) {  // this was after get_energy_gradient, moved for testing
+    _v[i] -= _dt * g_[i];  // update velocity, assumes all masses are 1
+    _dx[i] = _dt * _v[i];  // build displacement vector
   }
 
-  _gold.assign(g_); // save gradient as old g
+  _gold.assign(g_);  // save gradient as old g
   double normdx = compute_pot_norm(_dx);
 
   if (normdx > _maxstep) {
     _dx *= (_maxstep /
-            normdx); // resize displacement vector is greater than _maxstep
+            normdx);  // resize displacement vector is greater than _maxstep
   }
 
   x_ += _dx;
 
-  f_ = potential_->get_energy_gradient(x_, g_); // update gradient
+  f_ = potential_->get_energy_gradient(x_, g_);  // update gradient
 }
 
 inline void MODIFIED_FIRE::one_iteration() {
@@ -185,12 +187,12 @@ inline void MODIFIED_FIRE::one_iteration() {
   nfev_ += 1;
   iter_number_ += 1;
   _fire_iter_number +=
-      1; // this is different from iter_number_ which does not get reset
+      1;  // this is different from iter_number_ which does not get reset
 
   // save old configuration in case next step has P < 0
-  _fold = f_;       // set f_ old before integration step
-  _xold.assign(x_); // save x as xold, gold saved in integrator (because
-                    // velocity verlet needs it, if vv is used)
+  _fold = f_;        // set f_ old before integration step
+  _xold.assign(x_);  // save x as xold, gold saved in integrator (because
+                     // velocity verlet needs it, if vv is used)
 
   /*equation written in this conditional statement _v = (1- _a)*_v + _a * funit
    * * vnorm*/
@@ -213,7 +215,7 @@ inline void MODIFIED_FIRE::one_iteration() {
 
     _ifnorm = 1. / norm(g_);
     _vnorm = norm(_v);
-    gradient_norm_ = 1. / (_ifnorm * sqrt(_N)); // update rms
+    gradient_norm_ = 1. / (_ifnorm * sqrt(_N));  // update rms
   } else {
     _dt *= _fdec;
     _a = _astart;
@@ -248,6 +250,6 @@ inline void MODIFIED_FIRE::one_iteration() {
 #endif
 }
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef _PELE_MODIFIED_FIRE_H__
+#endif  // #ifndef _PELE_MODIFIED_FIRE_H__

--- a/source/pele/more_thuente.hpp
+++ b/source/pele/more_thuente.hpp
@@ -30,11 +30,12 @@
 #ifndef INCLUDE_CPPOPTLIB_LINESEARCH_MORE_THUENTE_H_
 #define INCLUDE_CPPOPTLIB_LINESEARCH_MORE_THUENTE_H_
 
-#include "eigen_interface.hpp"
-#include "linesearch.hpp"
 #include <Eigen/Dense>
 #include <cmath>
 #include <iostream>
+
+#include "eigen_interface.hpp"
+#include "linesearch.hpp"
 
 namespace pele {
 
@@ -43,16 +44,22 @@ using scalar_t = double;
 using vector_t = Array<double>;
 
 class MoreThuente : public LineSearch {
-public:
+ public:
   MoreThuente(GradientOptimizer *opt, double alpha_max = 1e15,
               double alpha_min = 1e-15, double x_tol = 1e-15,
               double f_tol = 1e-10, double g_tol = 1e-4, double x_trapf = 4,
               double max_fev = 40, double alphainit = 1.0)
-      : LineSearch(opt, alpha_max), xtol(x_tol), ftol(f_tol), gtol(g_tol),
-        xtrapf(x_trapf), maxfev(max_fev), alphamin(alpha_min),
-        alphamax(alpha_max), alpha_init(alphainit)
+      : LineSearch(opt, alpha_max),
+        xtol(x_tol),
+        ftol(f_tol),
+        gtol(g_tol),
+        xtrapf(x_trapf),
+        maxfev(max_fev),
+        alphamin(alpha_min),
+        alphamax(alpha_max),
+        alpha_init(alphainit)
 
-                                 {};
+            {};
 
   ~MoreThuente(){};
   // interfaced line search the line search assumes relevant variables are
@@ -60,7 +67,7 @@ public:
   double line_search(Array<double> &x, Array<double> step);
 
   // interfacing methods lbfgs
-public:
+ public:
   void inline set_xold_gold_(Array<double> &xold, Array<double> &gold) {
     gold_ = gold;
     xold_ = xold;
@@ -69,7 +76,7 @@ public:
   void inline set_g_f_ptr(Array<double> &g) { g_ = g; };
 
   // input variables
-private:
+ private:
   // info about the More Thuente Line search
 
   scalar_t alpha_init;
@@ -93,7 +100,7 @@ private:
   bool desdir;
 
   // methods
-public:
+ public:
   inline scalar_t search(const vector_t &x, const vector_t &search_direction) {
     // Assumed step width.
     scalar_t ak = alpha_init;
@@ -122,6 +129,6 @@ public:
             int &info);
 };
 
-}; // namespace pele
+};  // namespace pele
 
-#endif // INCLUDE_CPPOPTLIB_LINESEARCH_MORE_THUENTE_H_
+#endif  // INCLUDE_CPPOPTLIB_LINESEARCH_MORE_THUENTE_H_

--- a/source/pele/morse.hpp
+++ b/source/pele/morse.hpp
@@ -1,14 +1,15 @@
 #ifndef _PELE_MORSE_H_
 #define _PELE_MORSE_H_
 
+#include <cmath>
+#include <memory>
+
 #include "atomlist_potential.hpp"
 #include "base_interaction.hpp"
 #include "distance.hpp"
 #include "frozen_atoms.hpp"
 #include "simple_pairwise_ilist.hpp"
 #include "simple_pairwise_potential.hpp"
-#include <cmath>
-#include <memory>
 
 namespace pele {
 
@@ -55,10 +56,10 @@ struct morse_interaction : BaseInteraction {
  * Pairwise Lennard-Jones potential with smooth cutoff
  */
 class Morse : public SimplePairwisePotential<morse_interaction> {
-public:
+ public:
   Morse(double rho, double r0, double A)
       : SimplePairwisePotential<morse_interaction>(
             std::make_shared<morse_interaction>(rho, r0, A)) {}
 };
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/mxd_end_only.hpp
+++ b/source/pele/mxd_end_only.hpp
@@ -13,29 +13,30 @@
 #ifndef _PELE_MXD_END_ONLY_HPP
 #define _PELE_MXD_END_ONLY_HPP
 
-#include "base_potential.hpp"
-#include "pele/array.hpp"
-#include "pele/cvode.hpp"
-#include "pele/newton.hpp"
 #include <complex>
 #include <cstdint>
 #include <iostream>
 
+#include "base_potential.hpp"
+#include "pele/array.hpp"
+#include "pele/cvode.hpp"
+#include "pele/newton.hpp"
+
 namespace pele {
 
 class MixedDescentEndOnly : public GradientOptimizer {
-private:
+ private:
   double _tol;
   double _newton_step_tol;
   bool use_newton_step;
-  Array<double> particle_disp;  // Stores displacement for a single particle
-  double _max_dist;             // Maximum distance a single particle has moved
-  Array<uint8_t> _not_rattlers; // TODO: only because we need to save this
+  Array<double> particle_disp;   // Stores displacement for a single particle
+  double _max_dist;              // Maximum distance a single particle has moved
+  Array<uint8_t> _not_rattlers;  // TODO: only because we need to save this
 
   CVODEBDFOptimizer _cvode_optimizer;
   Newton _newton_optimizer;
 
-public:
+ public:
   MixedDescentEndOnly(std::shared_ptr<BasePotential> potential,
                       const pele::Array<double> x0, double tol = 1e-6,
                       double newton_step_tol = 1e-6, double rtol = 1e-6,
@@ -66,6 +67,6 @@ public:
     return Array<double>(step.data(), step.size());
   }
 };
-} // namespace pele
+}  // namespace pele
 
-#endif // _PELE_MXD_END_ONLY_HPP
+#endif  // _PELE_MXD_END_ONLY_HPP

--- a/source/pele/mxopt.hpp
+++ b/source/pele/mxopt.hpp
@@ -7,10 +7,11 @@
 
 // #define EIGEN_USE_MKL_ALL
 // Eigen linear algebra library
+#include <Eigen/Dense>
+
 #include "eigen_interface.hpp"
 #include "pele/lbfgs.hpp"
 #include "sundials/sundials_context.h"
-#include <Eigen/Dense>
 
 // Lapack for cholesky
 extern "C" {
@@ -18,6 +19,11 @@ extern "C" {
 }
 
 // line search methods
+#include <cvode/cvode.h>               /* access to CVODE                 */
+#include <nvector/nvector_serial.h>    /* access to serial N_Vector       */
+#include <sunlinsol/sunlinsol_dense.h> /* access to dense SUNLinearSolver */
+#include <sunmatrix/sunmatrix_dense.h> /* access to dense SUNMatrix       */
+
 #include "backtracking.hpp"
 #include "bracketing.hpp"
 #include "cvode.hpp"
@@ -25,11 +31,6 @@ extern "C" {
 #include "more_thuente.hpp"
 #include "nwpele.hpp"
 #include "optimizer.hpp"
-
-#include <cvode/cvode.h>               /* access to CVODE                 */
-#include <nvector/nvector_serial.h>    /* access to serial N_Vector       */
-#include <sunlinsol/sunlinsol_dense.h> /* access to dense SUNLinearSolver */
-#include <sunmatrix/sunmatrix_dense.h> /* access to dense SUNMatrix       */
 
 extern "C" {
 #include "xsum.h"
@@ -57,7 +58,7 @@ namespace pele {
  * from the minimum/ somewhat close to the minimum and near the minimum
  */
 class MixedOptimizer : public GradientOptimizer {
-private:
+ private:
   /**
    * H0 is the initial estimate for the inverse hessian. This is as small as
    * possible, for making a good inverse hessian estimate next time.
@@ -78,20 +79,20 @@ private:
   N_Vector x0_N;
   double rtol;
   double atol;
-  SUNContext sunctx; // SUNDIALS context
+  SUNContext sunctx;  // SUNDIALS context
 
-  Array<double> xold; //!< Coordinates before taking a step
-  Array<double> gold; //!< Gradient before taking a step
-  Array<double> step; //!< Step size and direction
+  Array<double> xold;  //!< Coordinates before taking a step
+  Array<double> gold;  //!< Gradient before taking a step
+  Array<double> step;  //!< Step size and direction
   double
-      inv_sqrt_size; //!< The inverse square root the the number of components
+      inv_sqrt_size;  //!< The inverse square root the the number of components
   // Preconditioning
-  int T_; // number of steps after which the lowest eigenvalues are recalculated
-          // in the first phase
+  int T_;  // number of steps after which the lowest eigenvalues are
+           // recalculated in the first phase
   // std::shared_ptr<Eigen::ColPivHouseholderQR<Eigen::MatrixXd>> solver;
   // solver for H x = b
-  Eigen::VectorXd
-  update_solver(Eigen::VectorXd r); // updates the solver with the new hessian
+  Eigen::VectorXd update_solver(
+      Eigen::VectorXd r);  // updates the solver with the new hessian
 
   char uplo; /* We ask LAPACK for the lower diagonal matrix L */
   int info;  /* "Info" return value, used for error-checking */
@@ -125,7 +126,7 @@ private:
   // Need to refactor line searches
   BacktrackingLineSearch line_search_method;
 
-public:
+ public:
   /**
    * Constructor
    */
@@ -154,9 +155,9 @@ public:
   inline int get_n_phase_1_steps() { return n_phase_1_steps; }
   inline int get_n_phase_2_steps() { return n_phase_2_steps; }
 
-private:
-  bool hessian_calculated; // checks whether the hessian has been calculated for
-                           // updating.
+ private:
+  bool hessian_calculated;  // checks whether the hessian has been calculated
+                            // for updating.
   void compute_phase_1_step(Array<double> step);
 
   void compute_phase_2_step(Array<double> step);
@@ -172,6 +173,6 @@ private:
   double pf;
 };
 
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/newton.hpp
+++ b/source/pele/newton.hpp
@@ -4,20 +4,21 @@
 #ifndef _PELE_NEWTON_H_
 #define _PELE_NEWTON_H_
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "eigen_interface.hpp"
-#include "pele/backtracking.hpp"
-#include "pele/optimizer.hpp"
 #include <Eigen/Dense>
 #include <array>
 #include <cstddef>
 #include <cstdint>
 
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "eigen_interface.hpp"
+#include "pele/backtracking.hpp"
+#include "pele/optimizer.hpp"
+
 namespace pele {
 
 class Newton : public GradientOptimizer {
-private:
+ private:
   Eigen::MatrixXd _hessian;
   Eigen::VectorXd _gradient;
   Eigen::VectorXd _x;
@@ -34,7 +35,7 @@ private:
   bool _jammed;
   bool _rattlers_found;
 
-public:
+ public:
   /**
    * @brief Newton method that ignores singular while calculating the inverse.
    * Uses a backtracking linesearch. If the hessian has singular values uses the
@@ -90,6 +91,6 @@ public:
                              Array<double> gradient);
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // !_PELE_NEWTON_H_
+#endif  // !_PELE_NEWTON_H_

--- a/source/pele/newton_with_extension.hpp
+++ b/source/pele/newton_with_extension.hpp
@@ -5,11 +5,6 @@
 #ifndef _PELE_NEWTON_WITH_EXTENSION_H_
 #define _PELE_NEWTON_WITH_EXTENSION_H_
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "eigen_interface.hpp"
-#include "pele/backtracking.hpp"
-#include "pele/optimizer.hpp"
 #include <Eigen/Dense>
 #include <array>
 #include <cstddef>
@@ -17,10 +12,16 @@
 #include <memory>
 #include <pele/combine_potentials.hpp>
 
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "eigen_interface.hpp"
+#include "pele/backtracking.hpp"
+#include "pele/optimizer.hpp"
+
 namespace pele {
 
 class NewtonWithExtendedPotential : public GradientOptimizer {
-private:
+ private:
   Eigen::MatrixXd _hessian;
   Eigen::VectorXd _gradient;
   Eigen::VectorXd _x;
@@ -43,7 +44,7 @@ private:
   // Sets the hessian
   bool hessian_calculated;
 
-public:
+ public:
   /**
    * @brief Newton method that ignores singular while calculating the inverse.
    * Uses a backtracking linesearch. If the hessian has singular values uses the
@@ -86,6 +87,6 @@ public:
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // !_PELE_NEWTON_H_
+#endif  // !_PELE_NEWTON_H_

--- a/source/pele/ngt.hpp
+++ b/source/pele/ngt.hpp
@@ -29,14 +29,14 @@ inline bool compare_degree(node_ptr u, node_ptr v) {
 }
 
 class NGT {
-public:
+ public:
   typedef std::map<std::pair<node_id, node_id>, double> rate_map_t;
 
   std::shared_ptr<Graph> _graph;
-  std::set<node_ptr> _A;             // the source nodes
-  std::set<node_ptr> _B;             // the sink nodes
-  std::list<node_ptr> intermediates; // this will an up to date list of nodes
-                                     // sorted by the node degree
+  std::set<node_ptr> _A;              // the source nodes
+  std::set<node_ptr> _B;              // the sink nodes
+  std::list<node_ptr> intermediates;  // this will an up to date list of nodes
+                                      // sorted by the node degree
   bool debug;
 
   /**
@@ -54,7 +54,7 @@ public:
   std::map<node_id, double> final_tau;
   std::map<node_id, double> final_committors;
   std::map<node_id, double>
-      weights; // normally these are equilibrium occupation probabilities
+      weights;  // normally these are equilibrium occupation probabilities
 
   ~NGT() {}
 
@@ -266,7 +266,7 @@ public:
    */
   void update_edge(node_ptr u, node_ptr v, edge_ptr ux, edge_ptr xv,
                    double omPxx) {
-    edge_ptr uv = u->get_successor_edge(v); // this is slow
+    edge_ptr uv = u->get_successor_edge(v);  // this is slow
     if (uv == NULL) {
       uv = add_edge(u, v);
     }
@@ -311,14 +311,12 @@ public:
          ++uxiter) {
       edge_ptr ux = *uxiter;
       node_ptr u = ux->tail();
-      if (u == x)
-        continue;
+      if (u == x) continue;
       for (auto xviter = x->out_edge_begin(); xviter != x->out_edge_end();
            ++xviter) {
         edge_ptr xv = *xviter;
         node_ptr v = xv->head();
-        if (v == x)
-          continue;
+        if (v == x) continue;
         //                if (u == v){
         //                    continue;
         //                }
@@ -623,5 +621,5 @@ public:
   }
 };
 
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/nwpele.hpp
+++ b/source/pele/nwpele.hpp
@@ -9,11 +9,12 @@
 
 #ifndef PELE_LINE_SEARCH_NOCEDAL_WRIGHT_H
 #define PELE_LINE_SEARCH_NOCEDAL_WRIGHT_H
+#include <Eigen/Core>
+
 #include "eigen_interface.hpp"
 #include "linesearch.hpp"
 #include "lsparameters.hpp"
 #include "optimizer.hpp"
-#include <Eigen/Core>
 
 using Scalar = double;
 typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
@@ -21,7 +22,7 @@ typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
 namespace pele {
 
 class NocedalWrightLineSearch : LineSearch {
-public:
+ public:
   NocedalWrightLineSearch(GradientOptimizer *opt,
                           Scalar max_step_ = Scalar(1.0), int m_ = 6,
                           Scalar epsilon_ = Scalar(1e-5),
@@ -32,9 +33,15 @@ public:
                           Scalar wolfe_ = Scalar(0.9))
       : params(m_, epsilon_, epsilon_rel_, past_, delta_, max_linesearch_,
                min_step_, max_step_, ftol_, wolfe_),
-        LineSearch(opt, max_step_), xsize(opt->get_x().size()),
-        xdum(opt->get_x().copy()), gdum(xsize), xvec(xsize), gradvec(xsize),
-        stpsize(Scalar(1.0)), xoldvec(xsize), step_direction(xsize){};
+        LineSearch(opt, max_step_),
+        xsize(opt->get_x().size()),
+        xdum(opt->get_x().copy()),
+        gdum(xsize),
+        xvec(xsize),
+        gradvec(xsize),
+        stpsize(Scalar(1.0)),
+        xoldvec(xsize),
+        step_direction(xsize){};
   virtual ~NocedalWrightLineSearch(){};
   inline void set_xold_gold_(Array<double> &xold, Array<double> &gold) {
     gold_ = gold;
@@ -44,7 +51,7 @@ public:
   inline void set_g_f_ptr(Array<double> &g) { g_ = g; };
   double line_search(Array<double> &x, Array<double> step);
 
-private:
+ private:
   LBFGSParam params;
   int xsize;
   double func_grad_wrapper(Vector &x, Vector &grad);
@@ -52,7 +59,7 @@ private:
   void LSFunc(Scalar &fx, Vector &x, Vector &grad, Scalar &step,
               const Vector &drt, const Vector &xp, const LBFGSParam &param);
 
-private:
+ private:
   Array<double> g_;
   Array<double> xold_;
   Array<double> gold_;
@@ -65,6 +72,6 @@ private:
   Vector xoldvec;
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // end ifndef PELE_LINE_SEARCH_NOCEDAL_WRIGHT_H
+#endif  // end ifndef PELE_LINE_SEARCH_NOCEDAL_WRIGHT_H

--- a/source/pele/optimizer.hpp
+++ b/source/pele/optimizer.hpp
@@ -333,19 +333,20 @@ class ODEBasedOptimizer : public GradientOptimizer {
   double time_;
 
   void update_trajectory() {
-    if (save_trajectory_) {
-      // Basics for what we need at this point
-      // Maybe an optional saving mechanism for the trajectory helps
-      time_trajectory_.push_back(time_);
-      gradient_norm_trajectory_.push_back(gradient_norm_);
-    }
+    // Basics for what we need at this point
+    // Maybe an optional saving mechanism for the trajectory helps
+    time_trajectory_.push_back(time_);
+    gradient_norm_trajectory_.push_back(gradient_norm_);
   }
 
  public:
   ODEBasedOptimizer(std::shared_ptr<pele::BasePotential> potential,
                     const pele::Array<double> x0, double tol = 1e-4,
-                    bool save_trajectory = false)
-      : GradientOptimizer(potential, x0, tol, save_trajectory), time_(0) {}
+                    bool save_trajectory = false,
+                    int iterations_before_save = 1)
+      : GradientOptimizer(potential, x0, tol, save_trajectory,
+                          iterations_before_save),
+        time_(0) {}
 
   virtual ~ODEBasedOptimizer() {}
 

--- a/source/pele/optimizer.hpp
+++ b/source/pele/optimizer.hpp
@@ -1,10 +1,6 @@
 #ifndef _PELE_OPTIMIZER_H__
 #define _PELE_OPTIMIZER_H__
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "preprocessor_directives.hpp"
-#include "xsum.h"
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
@@ -13,6 +9,11 @@
 #include <ostream>
 #include <stdexcept>
 #include <vector>
+
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "preprocessor_directives.hpp"
+#include "xsum.h"
 
 namespace pele {
 
@@ -28,7 +29,7 @@ namespace pele {
  * should derive from this class.
  */
 class Optimizer {
-public:
+ public:
   /**
    * virtual destructor
    */
@@ -66,7 +67,7 @@ public:
  * should derive from this class.
  */
 class GradientOptimizer : public Optimizer {
-protected:
+ protected:
   // input parameters
   /**
    * A pointer to the object that computes the function and gradient
@@ -112,15 +113,31 @@ protected:
 
   bool save_trajectory_; /**< Whether to save the trajectory */
 
-public:
+  int iterations_before_save_; /**< How often to save the trajectory */
+
+ public:
   GradientOptimizer(std::shared_ptr<pele::BasePotential> potential,
                     const pele::Array<double> x0, double tol = 1e-4,
-                    bool save_trajectory = false)
-      : potential_(potential), tol_(tol), maxstep_(0.1), maxiter_(1000),
-        iprint_(-1), verbosity_(0), iter_number_(0), nfev_(0), nhev_(0),
-        x_(x0.copy()), f_(0.), g_(x0.size()), gradient_norm_(1e10),
-        func_initialized_(false), last_step_failed_(false), succeeded_(false),
-        save_trajectory_(save_trajectory) {}
+                    bool save_trajectory = false,
+                    int iterations_before_save = 1)
+      : potential_(potential),
+        tol_(tol),
+        maxstep_(0.1),
+        maxiter_(1000),
+        iprint_(-1),
+        verbosity_(0),
+        iter_number_(0),
+        nfev_(0),
+        nhev_(0),
+        x_(x0.copy()),
+        f_(0.),
+        g_(x0.size()),
+        gradient_norm_(1e10),
+        func_initialized_(false),
+        last_step_failed_(false),
+        succeeded_(false),
+        save_trajectory_(save_trajectory),
+        iterations_before_save_(iterations_before_save) {}
 
   virtual ~GradientOptimizer() {}
 
@@ -131,8 +148,9 @@ public:
   }
 
   GradientOptimizer() : Optimizer() {
-    throw std::runtime_error("GradientOptimizer default constructor not "
-                             "implemented. Check derived class function calls");
+    throw std::runtime_error(
+        "GradientOptimizer default constructor not "
+        "implemented. Check derived class function calls");
   }
 
   /**
@@ -153,10 +171,9 @@ public:
     // iterate until the stop criterion is satisfied or maximum number of
     // iterations is reached
     for (int i = 0; i < niter; ++i) {
-      if (stop_criterion_satisfied())
-        break;
+      if (stop_criterion_satisfied()) break;
       one_iteration();
-      if (save_trajectory_)
+      if (save_trajectory_ && (iter_number_ % iterations_before_save_ == 0))
         update_trajectory();
     }
   }
@@ -246,7 +263,7 @@ public:
     return false;
   }
 
-protected:
+ protected:
   // /**
   //  * Compute the func and gradient of the objective function
   //  */
@@ -259,9 +276,9 @@ protected:
   //     func = potential_->get_energy_gradient(x, gradient);
   // }
 
-  virtual void
-  compute_func_gradient(Array<double> x, double &func,
-                        std::vector<xsum_small_accumulator> &gradient) {
+  virtual void compute_func_gradient(
+      Array<double> x, double &func,
+      std::vector<xsum_small_accumulator> &gradient) {
     nfev_ += 1;
 
     // pass the arrays to the potential
@@ -283,7 +300,7 @@ protected:
         "GradientOptimizer::update_trajectory must be overloaded");
   }
 
-public:
+ public:
   /**
    * functions for LineSearch
    */
@@ -307,13 +324,12 @@ public:
  * @brief Abstract base class for optimizers with a concept of time.
  */
 class ODEBasedOptimizer : public GradientOptimizer {
-
-private:
+ private:
   // Need to include others
   std::vector<double> time_trajectory_;
   std::vector<double> gradient_norm_trajectory_;
 
-protected:
+ protected:
   double time_;
 
   void update_trajectory() {
@@ -325,7 +341,7 @@ protected:
     }
   }
 
-public:
+ public:
   ODEBasedOptimizer(std::shared_ptr<pele::BasePotential> potential,
                     const pele::Array<double> x0, double tol = 1e-4,
                     bool save_trajectory = false)
@@ -340,14 +356,15 @@ public:
   }
 
   ODEBasedOptimizer() : GradientOptimizer() {
-    throw std::runtime_error("ODEBasedOptimizer default constructor not "
-                             "implemented. Check derived class function calls");
+    throw std::runtime_error(
+        "ODEBasedOptimizer default constructor not "
+        "implemented. Check derived class function calls");
   }
   std::vector<double> get_time_trajectory() { return time_trajectory_; }
   std::vector<double> get_gradient_norm_trajectory() {
     return gradient_norm_trajectory_;
   }
 };
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/pairwise_potential_interface.hpp
+++ b/source/pele/pairwise_potential_interface.hpp
@@ -1,9 +1,6 @@
 #ifndef PYGMIN_PAIRWISE_POTENTIAL_INTERFACE_H
 #define PYGMIN_PAIRWISE_POTENTIAL_INTERFACE_H
 
-#include "array.hpp"
-#include "base_potential.hpp"
-#include "utils.hpp"
 #include <bits/stdc++.h>
 #include <cassert>
 #include <cmath>
@@ -11,6 +8,10 @@
 #include <cstdint>
 #include <set>
 #include <vector>
+
+#include "array.hpp"
+#include "base_potential.hpp"
+#include "utils.hpp"
 using namespace std;
 
 namespace pele {
@@ -27,7 +28,7 @@ namespace pele {
  * @return double
  */
 class NonAdditiveCutoffCalculator {
-public:
+ public:
   NonAdditiveCutoffCalculator(double non_additivity, double cutoff_factor = 1.0)
       : _non_additivity(non_additivity), _cutoff_factor_(cutoff_factor) {}
   NonAdditiveCutoffCalculator() : _non_additivity(0) {}
@@ -39,13 +40,13 @@ public:
     return 2 * max_radius * _cutoff_factor_;
   }
 
-private:
+ private:
   double _non_additivity;
-  double _cutoff_factor_; // For the soft sphere potential defined in the paper
+  double _cutoff_factor_;  // For the soft sphere potential defined in the paper
 };
 
 class PairwisePotentialInterface : public BasePotential {
-protected:
+ protected:
   const Array<double> m_radii;
   const NonAdditiveCutoffCalculator m_cutoff_calculator;
   inline void initialize() {
@@ -70,7 +71,7 @@ protected:
     }
   }
 
-public:
+ public:
   PairwisePotentialInterface() : m_radii(0), m_cutoff_calculator(0) {}
   PairwisePotentialInterface(pele::Array<double> const &radii,
                              double non_additivity = 0)
@@ -137,18 +138,19 @@ public:
    */
   virtual inline double get_interaction_energy_gradient(double, double *,
                                                         size_t, size_t) const {
-    throw std::runtime_error("PairwisePotentialInterface::get_interaction_"
-                             "energy_gradient must be overloaded");
+    throw std::runtime_error(
+        "PairwisePotentialInterface::get_interaction_"
+        "energy_gradient must be overloaded");
   }
 
   /**
    * Return gradient and Hessian of interaction.
    */
-  virtual inline double
-  get_interaction_energy_gradient_hessian(double, double *, double *, size_t,
-                                          size_t) const {
-    throw std::runtime_error("PairwisePotentialInterface::get_interaction_"
-                             "energy_gradient_hessian must be overloaded");
+  virtual inline double get_interaction_energy_gradient_hessian(
+      double, double *, double *, size_t, size_t) const {
+    throw std::runtime_error(
+        "PairwisePotentialInterface::get_interaction_"
+        "energy_gradient_hessian must be overloaded");
   }
 
   /**
@@ -306,7 +308,7 @@ public:
           }
         }
       }
-    } // end while
+    }  // end while
     size_t n_stable_particles = n_particles - n_rattlers;
 
     size_t total_contacts = 0;
@@ -332,6 +334,6 @@ public:
   }
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef PYGMIN_PAIRWISE_POTENTIAL_INTERFACE_H
+#endif  // #ifndef PYGMIN_PAIRWISE_POTENTIAL_INTERFACE_H

--- a/source/pele/preprocessor_directives.hpp
+++ b/source/pele/preprocessor_directives.hpp
@@ -20,4 +20,4 @@
  */
 #define PRINT_TO_FILE 1
 
-#endif // PELE_FLAGS
+#endif  // PELE_FLAGS

--- a/source/pele/pressure_tensor.hpp
+++ b/source/pele/pressure_tensor.hpp
@@ -9,6 +9,6 @@ double pressure_tensor(std::shared_ptr<pele::BasePotential> pot,
                        pele::Array<double> x, pele::Array<double> ptensor,
                        const double volume);
 
-} // namespace pele
+}  // namespace pele
 
-#endif // #ifndef _PELE_PRESSURE_TENSOR_H
+#endif  // #ifndef _PELE_PRESSURE_TENSOR_H

--- a/source/pele/python_potential_wrapper.hpp
+++ b/source/pele/python_potential_wrapper.hpp
@@ -1,11 +1,12 @@
 #ifndef _PELE_POTENTIAL_FUNCTION_H
 #define _PELE_POTENTIAL_FUNCTION_H
-#include "array.hpp"
-#include "base_potential.hpp"
 #include <Python.h>
 #include <iostream>
 #include <numpy/arrayobject.h>
 #include <stdexcept>
+
+#include "array.hpp"
+#include "base_potential.hpp"
 
 //#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
@@ -50,7 +51,7 @@ get_energy_gradient(Array<double> const & x, Array<double> & grad) {  return
 class PythonPotential : public BasePotential {
   PyObject *_potential;
 
-public:
+ public:
   PythonPotential(PyObject *potential) : _potential(potential) {
     Py_XINCREF(_potential);
 
@@ -157,8 +158,8 @@ public:
 
     // parse the returned tuple into a doulbe and a numpy array
     double energy;
-    PyObject *npgrad_returned; // the reference count for this does not need to
-                               // be decreased
+    PyObject *npgrad_returned;  // the reference count for this does not need to
+                                // be decreased
     if (!PyArg_ParseTuple(returnval, "dO", &energy, &npgrad_returned)) {
       Py_XDECREF(returnval);
       throw std::runtime_error("failed to parse the tuple");
@@ -173,8 +174,9 @@ public:
                         1, NPY_CARRAY, NULL);
     if (!npgrad_safe) {
       Py_XDECREF(returnval);
-      throw std::runtime_error("gradient returned by getEnergyGradient could "
-                               "not be converted to numpy double array");
+      throw std::runtime_error(
+          "gradient returned by getEnergyGradient could "
+          "not be converted to numpy double array");
     }
     // check the size of the gradient array
     if (static_cast<size_t>(PyArray_Size(npgrad_safe)) != grad.size()) {
@@ -200,5 +202,5 @@ public:
     return energy;
   }
 };
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/queue.hpp
+++ b/source/pele/queue.hpp
@@ -7,11 +7,12 @@
 /**
  * A queue with a thread-safe push method
  */
-template <typename T> class SafePushQueue : public std::queue<T> {
-protected:
+template <typename T>
+class SafePushQueue : public std::queue<T> {
+ protected:
   std::mutex m_mutex;
 
-public:
+ public:
   void push(const T &item) {
     std::unique_lock<std::mutex> mlock(m_mutex);
     std::queue<T>::push(item);
@@ -19,4 +20,4 @@ public:
   }
 };
 
-#endif // #ifndef _PELE_QUEUE_H_
+#endif  // #ifndef _PELE_QUEUE_H_

--- a/source/pele/rosenbrock.hpp
+++ b/source/pele/rosenbrock.hpp
@@ -1,23 +1,23 @@
 #ifndef _PELE_TEST_FUNCS_H
 #define _PELE_TEST_FUNCS_H
 
-#include "array.hpp"
-#include "base_potential.hpp"
-
 #include <iostream>
 #include <memory>
 #include <vector>
+
+#include "array.hpp"
+#include "base_potential.hpp"
 
 namespace pele {
 /**
  * RosenBrock function with defaults for testing purposes
  */
 class RosenBrock : public BasePotential {
-private:
+ private:
   double m_a;
   double m_b;
 
-public:
+ public:
   RosenBrock(double a = 1, double b = 100) : m_a(a), m_b(b){};
   virtual ~RosenBrock(){};
   inline double get_energy(Array<double> const &x) {
@@ -39,13 +39,13 @@ public:
  * Saddle point function for optimizer testing purposes
  */
 class Saddle : public BasePotential {
-private:
+ private:
   double m_a2;
   double m_b2;
   double m_a4;
   double m_b4;
 
-public:
+ public:
   Saddle(double a2 = 2, double b2 = 2, double a4 = 1, double b4 = 1)
       : m_a2(a2), m_b2(b2), m_a4(a4), m_b4(b4){};
   virtual ~Saddle(){};
@@ -69,7 +69,7 @@ public:
  *
  */
 class XCube : public BasePotential {
-public:
+ public:
   XCube(){};
   virtual ~XCube(){};
   inline double get_energy(Array<double> const &x) {
@@ -91,10 +91,10 @@ public:
  */
 
 class FlatHarmonic : public BasePotential {
-private:
+ private:
   double m_a;
 
-public:
+ public:
   FlatHarmonic(double a = 1) : m_a(a){};
   virtual ~FlatHarmonic(){};
   inline double get_energy(Array<double> const &x) { return m_a * x[0] * x[0]; }
@@ -120,5 +120,5 @@ public:
   };
 };
 
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/rotations.hpp
+++ b/source/pele/rotations.hpp
@@ -46,5 +46,5 @@ void rot_mat_derivatives(pele::VecN<3> const &p, pele::MatrixNM<3, 3> &rmat,
                          pele::MatrixNM<3, 3> &drm1, pele::MatrixNM<3, 3> &drm2,
                          pele::MatrixNM<3, 3> &drm3);
 
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/simple_pairwise_ilist.hpp
+++ b/source/pele/simple_pairwise_ilist.hpp
@@ -1,13 +1,14 @@
 #ifndef PYGMIN_SIMPLE_PAIRWISE_ILIST_H
 #define PYGMIN_SIMPLE_PAIRWISE_ILIST_H
 
-#include "array.hpp"
-#include "distance.hpp"
-#include "pairwise_potential_interface.hpp"
 #include <assert.h>
 #include <iostream>
 #include <memory>
 #include <vector>
+
+#include "array.hpp"
+#include "distance.hpp"
+#include "pairwise_potential_interface.hpp"
 
 namespace pele {
 /**
@@ -19,7 +20,7 @@ namespace pele {
 template <typename pairwise_interaction,
           typename distance_policy = cartesian_distance<3>>
 class SimplePairwiseNeighborList : public PairwisePotentialInterface {
-protected:
+ protected:
   std::shared_ptr<pairwise_interaction> _interaction;
   std::shared_ptr<distance_policy> _dist;
   std::vector<size_t> const _neighbor_list;
@@ -29,23 +30,23 @@ protected:
                              Array<size_t> const &neighbor_list,
                              const Array<double> radii,
                              std::shared_ptr<distance_policy> dist = NULL)
-      : PairwisePotentialInterface(radii), _interaction(interaction),
+      : PairwisePotentialInterface(radii),
+        _interaction(interaction),
         _dist(dist),
         _neighbor_list(neighbor_list.begin(), neighbor_list.end()) {
-    if (_dist == NULL)
-      _dist = std::make_shared<distance_policy>();
+    if (_dist == NULL) _dist = std::make_shared<distance_policy>();
   }
 
   SimplePairwiseNeighborList(std::shared_ptr<pairwise_interaction> interaction,
                              Array<size_t> const &neighbor_list,
                              std::shared_ptr<distance_policy> dist = NULL)
-      : _interaction(interaction), _dist(dist),
+      : _interaction(interaction),
+        _dist(dist),
         _neighbor_list(neighbor_list.begin(), neighbor_list.end()) {
-    if (_dist == NULL)
-      _dist = std::make_shared<distance_policy>();
+    if (_dist == NULL) _dist = std::make_shared<distance_policy>();
   }
 
-public:
+ public:
   virtual ~SimplePairwiseNeighborList() {}
 
   virtual double get_energy(Array<double> const &x);
@@ -68,9 +69,10 @@ public:
 };
 
 template <typename pairwise_interaction, typename distance_policy>
-inline double
-SimplePairwiseNeighborList<pairwise_interaction, distance_policy>::
-    add_energy_gradient(Array<double> const &x, Array<double> &grad) {
+inline double SimplePairwiseNeighborList<
+    pairwise_interaction,
+    distance_policy>::add_energy_gradient(Array<double> const &x,
+                                          Array<double> &grad) {
   double e = 0.;
   double gij, dr[_ndim];
   const size_t nlist = _neighbor_list.size();
@@ -100,7 +102,8 @@ SimplePairwiseNeighborList<pairwise_interaction, distance_policy>::
       r2 += dr[k] * dr[k];
     }
 
-    e += _interaction->energy_gradient(r2, &gij, get_non_additive_cutoff(atom1, atom2));
+    e += _interaction->energy_gradient(r2, &gij,
+                                       get_non_additive_cutoff(atom1, atom2));
     for (size_t k = 0; k < _ndim; ++k) {
       grad[i1 + k] -= gij * dr[k];
     }
@@ -137,6 +140,6 @@ SimplePairwiseNeighborList<pairwise_interaction, distance_policy>::get_energy(
 
   return e;
 }
-} // namespace pele
+}  // namespace pele
 
 #endif

--- a/source/pele/steepest.hpp
+++ b/source/pele/steepest.hpp
@@ -6,14 +6,16 @@
  * ill conditioned problems
  */
 
-#include "array.hpp"
-#include "base_potential.hpp"
 #include <memory>
 #include <vector>
 
+#include "array.hpp"
+#include "base_potential.hpp"
+
 // Eigen linear algebra library
-#include "eigen_interface.hpp"
 #include <Eigen/Dense>
+
+#include "eigen_interface.hpp"
 
 // line search methods
 #include "backtracking.hpp"
@@ -30,11 +32,11 @@ namespace pele {
  */
 
 class Steepest_Descent : public GradientOptimizer {
-private:
-  double m_initial_step; // initial step size for steepest descent
+ private:
+  double m_initial_step;  // initial step size for steepest descent
   std::shared_ptr<LineSearch> line_search_method;
 
-public:
+ public:
   Steepest_Descent(std::shared_ptr<pele::BasePotential> potential,
                    const pele::Array<double> x0, double tol = 1e-4,
                    double initial_step = 1)
@@ -44,6 +46,6 @@ public:
   virtual ~Steepest_Descent(){};
 };
 
-} // namespace pele
+}  // namespace pele
 
-#endif // end _PELE_STEEPEST_DESCENT_H__
+#endif  // end _PELE_STEEPEST_DESCENT_H__

--- a/source/pele/utils.hpp
+++ b/source/pele/utils.hpp
@@ -4,13 +4,14 @@
  * Utility functions for testing and debugging.
  */
 
-#include "pele/array.hpp"
 #include <cmath>
 #include <cstddef>
 #include <iostream>
 #include <math.h>
 #include <random>
 #include <vector>
+
+#include "pele/array.hpp"
 
 // Float definition of pi
 #define PI 3.14159265358979323846
@@ -35,9 +36,9 @@ namespace pele {
  *
  * @return     Array of radii
  */
-inline Array<double> generate_bidisperse_radii(int n_1, int n_2, double r_1, double r_2,
-                                    double r_std_1, double r_std_2) {
-
+inline Array<double> generate_bidisperse_radii(int n_1, int n_2, double r_1,
+                                               double r_2, double r_std_1,
+                                               double r_std_2) {
   Array<double> radii(n_1 + n_2);
 
   std::random_device rd;
@@ -53,71 +54,71 @@ inline Array<double> generate_bidisperse_radii(int n_1, int n_2, double r_1, dou
 }
 
 class BerthierDistribution3d {
-    public:
-        /**
-         * Distribution is given by
-         * p(x) = norm/(x^3)  where x in [dmin, dmax]
-         *
-         * Parameters
-         * ----------
-         * delta : float
-         *     stdev(diameter) / mean(diameter)
-         * dmin_by_dmax : float
-         *     dmin / dmax
-         * d_av : float
-         *     mean(diameter)
-         * seed : int
-         */
-        BerthierDistribution3d(double dmin_by_dmax, double d_mean, int seed=0)
-        : norm(0.5 * d_mean * d_mean * (1 + dmin_by_dmax) / (1 - dmin_by_dmax)),
-              dmin(d_mean * 0.5 * (1 + dmin_by_dmax)),
-              dmax(dmin / dmin_by_dmax),
-              d_mean(d_mean),
-              uniform(0., 1.)
-        {}
+ public:
+  /**
+   * Distribution is given by
+   * p(x) = norm/(x^3)  where x in [dmin, dmax]
+   *
+   * Parameters
+   * ----------
+   * delta : float
+   *     stdev(diameter) / mean(diameter)
+   * dmin_by_dmax : float
+   *     dmin / dmax
+   * d_av : float
+   *     mean(diameter)
+   * seed : int
+   */
+  BerthierDistribution3d(double dmin_by_dmax, double d_mean, int seed = 0)
+      : norm(0.5 * d_mean * d_mean * (1 + dmin_by_dmax) / (1 - dmin_by_dmax)),
+        dmin(d_mean * 0.5 * (1 + dmin_by_dmax)),
+        dmax(dmin / dmin_by_dmax),
+        d_mean(d_mean),
+        uniform(0., 1.) {}
 
-        inline double _inverse_cdf(double x) {
-            /**
-             * Inverse of the cdf of the distribution.
-             * used to sample, see https://en.wikipedia.org/wiki/Inverse_transform_sampling
-             *
-             * converts a sample from a uniform random distribution in [0, 1] to a sample from
-             * the berthier distribution
-             */
-            if (x < 0 || x > 1) {
-                throw std::invalid_argument("x must be in [0,1]");
-            }
-            // comes from solving the integral of the pdf
-            double inv_x_2 = 1 / (dmin * dmin) - 2 * x / norm;
-            return 1 / sqrt(inv_x_2);
-        }
+  inline double _inverse_cdf(double x) {
+    /**
+     * Inverse of the cdf of the distribution.
+     * used to sample, see
+     * https://en.wikipedia.org/wiki/Inverse_transform_sampling
+     *
+     * converts a sample from a uniform random distribution in [0, 1] to a
+     * sample from the berthier distribution
+     */
+    if (x < 0 || x > 1) {
+      throw std::invalid_argument("x must be in [0,1]");
+    }
+    // comes from solving the integral of the pdf
+    double inv_x_2 = 1 / (dmin * dmin) - 2 * x / norm;
+    return 1 / sqrt(inv_x_2);
+  }
 
-        Array<double> sample(size_t n) {
-            Array<double> sample(n);
-            for (size_t i = 0; i < n; ++i) {
-                sample[i] = _inverse_cdf(uniform(generator));
-            }
-            return sample;
-        }
+  Array<double> sample(size_t n) {
+    Array<double> sample(n);
+    for (size_t i = 0; i < n; ++i) {
+      sample[i] = _inverse_cdf(uniform(generator));
+    }
+    return sample;
+  }
 
-        double pdf(double x) {
-            if (x < dmin || x > dmax) {
-                return 0;
-            }
-            return norm / (x * x * x);
-        }
+  double pdf(double x) {
+    if (x < dmin || x > dmax) {
+      return 0;
+    }
+    return norm / (x * x * x);
+  }
 
-    private:
-        double norm;
-        double dmin;
-        double dmax;
-        double d_mean;
-        std::default_random_engine generator;
-        std::uniform_real_distribution<double> uniform;
+ private:
+  double norm;
+  double dmin;
+  double dmax;
+  double d_mean;
+  std::default_random_engine generator;
+  std::uniform_real_distribution<double> uniform;
 };
 
-template <typename T> vector<size_t> sort_indexes(const vector<T> &v) {
-
+template <typename T>
+vector<size_t> sort_indexes(const vector<T> &v) {
   // initialize original index locations
   vector<size_t> idx(v.size());
   iota(idx.begin(), idx.end(), 0);
@@ -144,7 +145,8 @@ inline void print_matrix(matrix m) {
   }
 }
 
-template <class T> inline void print_vector(std::vector<T> v) {
+template <class T>
+inline void print_vector(std::vector<T> v) {
   for (size_t i = 0; i < v.size(); i++) {
     std::cout << v[i] << " ";
   }
@@ -186,7 +188,6 @@ inline double get_box_length(Array<double> hs_radii, int dim, double phi) {
  */
 inline Array<double> generate_random_coordinates(double box_length,
                                                  int n_particles, int dim) {
-
   Array<double> coords(n_particles * dim);
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -202,7 +203,6 @@ inline Array<double> generate_random_coordinates(double box_length,
 
 inline std::vector<double> cross_shifted(matrix x, std::vector<size_t> shift_x,
                                          std::vector<size_t> shift_y) {
-
   std::vector<double> cross_product(x.size());
   for (size_t i = 0; i < x.size(); i++) {
     cross_product[i] = x[shift_x[i]][0] * x[shift_y[i]][1] -
@@ -288,5 +288,5 @@ inline bool origin_in_hull_2d(matrix vertices) {
   return false;
 }
 
-} // namespace pele
-#endif // !1
+}  // namespace pele
+#endif  // !1

--- a/source/pele/vecn.hpp
+++ b/source/pele/vecn.hpp
@@ -1,7 +1,6 @@
 #ifndef _pele_vecn_h_
 #define _pele_vecn_h_
 
-#include "array.hpp"
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -10,12 +9,15 @@
 #include <string>
 #include <vector>
 
+#include "array.hpp"
+
 namespace pele {
 
-template <size_t N, typename dtype = double> class VecN {
+template <size_t N, typename dtype = double>
+class VecN {
   dtype m_data[N];
 
-public:
+ public:
   /**
    * default constructor
    */
@@ -40,7 +42,8 @@ public:
   /**
    * initialize values from input iterators
    */
-  template <class input_iter> VecN(input_iter ibegin, input_iter iend) {
+  template <class input_iter>
+  VecN(input_iter ibegin, input_iter iend) {
     std::copy(ibegin, iend, this->begin());
   }
 
@@ -194,13 +197,14 @@ public:
     return p;
   }
 
-}; // close VecN
+};  // close VecN
 
-template <size_t N, size_t M, typename dtype = double> class MatrixNM {
+template <size_t N, size_t M, typename dtype = double>
+class MatrixNM {
   static size_t const m_size = N * M;
   dtype m_data[m_size];
 
-public:
+ public:
   /**
    * default constructor
    */
@@ -284,7 +288,7 @@ public:
     return v;
   }
 
-}; // close MatrixNM
+};  // close MatrixNM
 
 /**
  * compute the dot product of two Arrays
@@ -372,12 +376,10 @@ inline std::ostream &operator<<(std::ostream &out,
   out << "[ ";
   for (size_t n = 0; n < N; ++n) {
     for (size_t m = 0; m < M; ++m) {
-      if (m > 0)
-        out << ", ";
+      if (m > 0) out << ", ";
       out << a(n, m);
     }
-    if (n < N - 1)
-      out << ",\n  ";
+    if (n < N - 1) out << ",\n  ";
   }
   out << " ]";
   return out;
@@ -388,13 +390,12 @@ template <size_t N, typename dtype>
 inline std::ostream &operator<<(std::ostream &out, const VecN<N, dtype> &a) {
   out << "[ ";
   for (size_t i = 0; i < a.size(); ++i) {
-    if (i > 0)
-      out << ", ";
+    if (i > 0) out << ", ";
     out << a[i];
   }
   out << " ]";
   return out;
 }
 
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pele/wca.hpp
+++ b/source/pele/wca.hpp
@@ -15,12 +15,17 @@ namespace pele {
 struct WCA_interaction : BaseInteraction {
   double const _C6, _C12;
   double const _6C6, _12C12, _42C6, _156C12;
-  double const _coff2, _eps; // cutoff distance for WCA potential
+  double const _coff2, _eps;  // cutoff distance for WCA potential
 
   WCA_interaction(double sig, double eps)
-      : _C6(sig * sig * sig * sig * sig * sig), _C12(_C6 * _C6), _6C6(6. * _C6),
-        _12C12(12. * _C12), _42C6(42 * _C6), _156C12(156 * _C12),
-        _coff2(pow(2., 1. / 3) * sig * sig), _eps(eps) {}
+      : _C6(sig * sig * sig * sig * sig * sig),
+        _C12(_C6 * _C6),
+        _6C6(6. * _C6),
+        _12C12(12. * _C12),
+        _42C6(42 * _C6),
+        _156C12(156 * _C12),
+        _coff2(pow(2., 1. / 3) * sig * sig),
+        _eps(eps) {}
 
   /* calculate energy from distance squared */
   double energy(double r2, const double dij) const {
@@ -38,8 +43,7 @@ struct WCA_interaction : BaseInteraction {
 
   /* calculate energy and gradient from distance squared, gradient is in
    * -(dv/drij)/|rij| */
-  double energy_gradient(double r2, double *gij,
-                         const double dij) const {
+  double energy_gradient(double r2, double *gij, const double dij) const {
     double E;
     double ir2 = 1.0 / r2;
     double ir6 = ir2 * ir2 * ir2;
@@ -86,7 +90,7 @@ struct WCA_interaction : BaseInteraction {
  */
 class WCA
     : public SimplePairwisePotential<WCA_interaction, cartesian_distance<3>> {
-public:
+ public:
   WCA(double sig, double eps)
       : SimplePairwisePotential<WCA_interaction, cartesian_distance<3>>(
             std::make_shared<WCA_interaction>(sig, eps),
@@ -95,7 +99,7 @@ public:
 
 class WCA2D
     : public SimplePairwisePotential<WCA_interaction, cartesian_distance<2>> {
-public:
+ public:
   WCA2D(double sig, double eps)
       : SimplePairwisePotential<WCA_interaction, cartesian_distance<2>>(
             std::make_shared<WCA_interaction>(sig, eps),
@@ -107,7 +111,7 @@ public:
  */
 class WCAPeriodic
     : public SimplePairwisePotential<WCA_interaction, periodic_distance<3>> {
-public:
+ public:
   WCAPeriodic(double sig, double eps, Array<double> const boxvec)
       : SimplePairwisePotential<WCA_interaction, periodic_distance<3>>(
             std::make_shared<WCA_interaction>(sig, eps),
@@ -119,7 +123,7 @@ public:
  */
 class WCAPeriodic2D
     : public SimplePairwisePotential<WCA_interaction, periodic_distance<2>> {
-public:
+ public:
   WCAPeriodic2D(double sig, double eps, Array<double> const boxvec)
       : SimplePairwisePotential<WCA_interaction, periodic_distance<2>>(
             std::make_shared<WCA_interaction>(sig, eps),
@@ -130,7 +134,7 @@ public:
  * Pairwise WCA potential with interaction lists
  */
 class WCANeighborList : public SimplePairwiseNeighborList<WCA_interaction> {
-public:
+ public:
   WCANeighborList(Array<size_t> &ilist, double sig, double eps)
       : SimplePairwiseNeighborList<WCA_interaction>(
             std::make_shared<WCA_interaction>(sig, eps), ilist) {}
@@ -138,7 +142,7 @@ public:
 
 class WCAAtomList
     : public AtomListPotential<WCA_interaction, cartesian_distance<3>> {
-public:
+ public:
   WCAAtomList(double sig, double eps, Array<size_t> atoms1,
               Array<size_t> atoms2)
       : AtomListPotential<WCA_interaction, cartesian_distance<3>>(
@@ -150,5 +154,5 @@ public:
             std::make_shared<cartesian_distance<3>>(), atoms1) {}
 };
 
-} // namespace pele
+}  // namespace pele
 #endif

--- a/source/pressure_tensor.cpp
+++ b/source/pressure_tensor.cpp
@@ -1,4 +1,5 @@
 #include "pele/pressure_tensor.hpp"
+
 #include "pele/simple_pairwise_potential.hpp"
 
 namespace pele {
@@ -54,4 +55,4 @@ double pressure_tensor(std::shared_ptr<pele::BasePotential> pot_,
   return traceP / ndim;
 }
 
-} // namespace pele
+}  // namespace pele

--- a/source/rotations.cpp
+++ b/source/rotations.cpp
@@ -1,4 +1,5 @@
 #include "pele/rotations.hpp"
+
 #include "pele/vecn.hpp"
 
 namespace pele {
@@ -7,7 +8,6 @@ namespace pele {
  * make a rotation matrix from an angle axis
  */
 MatrixNM<3, 3> aa_to_rot_mat(pele::VecN<3> const &p) {
-
   double theta2 = pele::dot<3>(p, p);
   MatrixNM<3, 3> rm;
   if (theta2 < 1e-12) {
@@ -41,8 +41,7 @@ MatrixNM<3, 3> aa_to_rot_mat(pele::VecN<3> const &p) {
   // in the paper]
   // rm  = np.eye(3) + [1. - ct] * esq + st * e
   rm.assign(0);
-  for (size_t i = 0; i < 3; ++i)
-    rm(i, i) = 1; // identiy matrix
+  for (size_t i = 0; i < 3; ++i) rm(i, i) = 1;  // identiy matrix
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
       rm(i, j) += (1. - ct) * esq(i, j) + st * e(i, j);
@@ -132,8 +131,7 @@ pele::VecN<4> aa_to_quaternion(pele::VecN<3> const &aa) {
   }
 
   // make sure to have normal form
-  if (q[0] < 0.0)
-    q *= -1;
+  if (q[0] < 0.0) q *= -1;
   return q;
 }
 
@@ -162,8 +160,7 @@ void rot_mat_derivatives_small_theta(pele::VecN<3> const &p,
   // Execute if the angle of rotation is zero
   // In this case the rotation matrix is the identity matrix
   rmat.assign(0);
-  for (size_t i = 0; i < 3; ++i)
-    rmat(i, i) = 1; // identity matrix
+  for (size_t i = 0; i < 3; ++i) rmat(i, i) = 1;  // identity matrix
 
   // vr274> first order corrections to rotation matrix
   rmat(0, 1) = -p[2];
@@ -268,8 +265,7 @@ void rot_mat_derivatives(pele::VecN<3> const &p, MatrixNM<3, 3> &rmat,
   // in the paper]
   // rm  = np.eye(3) + [1. - ct] * esq + st * e
   rmat.assign(0.);
-  for (size_t i = 0; i < 3; ++i)
-    rmat(i, i) = 1; // identiy matrix
+  for (size_t i = 0; i < 3; ++i) rmat(i, i) = 1;  // identiy matrix
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
       rmat(i, j) += (1. - ct) * esq(i, j) + st * e(i, j);
@@ -336,4 +332,4 @@ void rot_mat_derivatives(pele::VecN<3> const &p, MatrixNM<3, 3> &rmat,
   }
 }
 
-} // namespace pele
+}  // namespace pele


### PR DESCRIPTION
figured out a way to make clang-format not cause compilation errors when gtest was being imported.

Added functionality for saving the trajectory every $N$ steps